### PR TITLE
Replace fluidsim with fluidsim-core

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,10 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install .[tests]
+        pip install \
+            --index-url https://test.pypi.org/simple \
+            --extra-index-url https://pypi.org/simple \
+            .[tests]
 
     - name: Run tests
       run: |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Install it as follows:
 ```sh
 export NEK_SOURCE_ROOT="/path/to/Nek5000"
 export PATH="$PATH:$NEK_SOURCE_ROOT/bin"
-export FLUIDSIM_TRANSONIC_BACKEND=python
 
 pip install snek5000
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ package_dir=
 packages=find:
 install_requires =
     snakemake != 5.23.*, != 5.24.*
-    fluidsim-core >= 0.3.3
+    fluidsim-core
     entrypoints
     jinja2
     inflection

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ package_dir=
 packages=find:
 install_requires =
     snakemake != 5.23.*, != 5.24.*
-    fluidsim >= 0.3.3
+    fluidsim-core >= 0.3.3
     entrypoints
     jinja2
     inflection

--- a/src/snek5000/__init__.py
+++ b/src/snek5000/__init__.py
@@ -85,9 +85,9 @@ def load_simul(path_dir):
         solver = path_dir.name.split("_")[0]
 
     # Load simulation class
-    from snek5000.solvers import import_solver
+    from snek5000.solvers import import_cls_simul
 
-    Simul = import_solver(solver)
+    Simul = import_cls_simul(solver)
 
     # Load parameters
     params_xml = path_dir / "params.xml"

--- a/src/snek5000/__init__.py
+++ b/src/snek5000/__init__.py
@@ -98,5 +98,6 @@ def load_simul(path_dir):
         params_par = None
 
     params = Simul.load_params_from_file(path_xml=params_xml, path_par=params_par)
+    params.NEW_DIR_RESULTS = False
     sim = Simul(params, existing_path_run=path_dir)
     return sim

--- a/src/snek5000/info.py
+++ b/src/snek5000/info.py
@@ -5,10 +5,10 @@ Store information regarding modules and class names of simulation class and
 dependent objects.
 
 """
-from fluidsim.base.solvers.info_base import InfoSolverBase
+from fluidsim_core.info import InfoSolverCore
 
 
-class InfoSolverNek(InfoSolverBase):
+class InfoSolverNek(InfoSolverCore):
     """Contain the information on a :class:`snek5000.solvers.base.Simul`
     instance.
 
@@ -30,7 +30,12 @@ class InfoSolverNek(InfoSolverBase):
                     "scalar01",
                     "cvode",
                 ),
-                "par_sections_disabled": ("mesh", "temperature", "scalar01", "cvode",),
+                "par_sections_disabled": (
+                    "mesh",
+                    "temperature",
+                    "scalar01",
+                    "cvode",
+                ),
             }
         )
         self._set_child("classes")
@@ -41,10 +46,7 @@ class InfoSolverNek(InfoSolverBase):
 
 
 class InfoSolverMake(InfoSolverNek):
-    """Contain the information on a solver which uses Snakemake.
-
-
-    """
+    """Contain the information on a solver which uses Snakemake."""
 
     def _init_root(self):
         super()._init_root()

--- a/src/snek5000/magic.py
+++ b/src/snek5000/magic.py
@@ -6,57 +6,85 @@ Usage example in an IPython console:
 .. code-block:: ipython
 
    In [1]: %load_ext snek5000.magic
-   WARNING  Activating this magic involves dirty monkey-patching of fluidsim.magic
 
-   In [2]: %snek5000 abl
+   In [2]: %snek abl
    INFO     Reading baseline parameters from /home/avmo/src/exabl/snek5000/src/abl/abl.par
    Created Simul class and default parameters for abl -> Simul, params
 
    In [3]: sim = Simul(params)
 
 """
-import pkgutil
-from importlib import import_module
-
-from fluidsim import magic as fluidsim_magic
-from IPython.core import magic_arguments
+from fluidsim_core.magic import MagicsCore
 from IPython.core.magic import line_magic, magics_class
-
-from .log import logger
-
-
-def available_solver_keys(package):
-    package = import_module(package)
-    modules = [
-        mod.name for mod in pkgutil.walk_packages(package.__path__) if not mod.ispkg
-    ]
-    return modules
-
-
-def import_simul_class_from_key(key, package):
-    solver = import_module(f"{package}.{key}")
-    return solver.Simul
-
-
-# Monkey patch
-fluidsim_magic.available_solver_keys = available_solver_keys
-fluidsim_magic.import_simul_class_from_key = import_simul_class_from_key
+from IPython.core.magic_arguments import argument, magic_arguments
 
 
 @magics_class
-class EturbMagics(fluidsim_magic.FluidsimMagics):
-    @magic_arguments.magic_arguments()
-    @magic_arguments.argument("solver", nargs="?", default="")
-    @magic_arguments.argument("-f", "--force-overwrite", action="store_true")
+class SnekMagics(MagicsCore):
+    """Magic commands can be loaded in IPython or Jupyter as
+
+    >>> %load_ext fluidsim.magic
+
+    Examples
+    --------
+
+    - Magic command %fluidsim or %snek (alias)
+
+    %snek creates the variables `params` and `Simul` for a particular solver.
+
+    Create default parameters for a solver:
+
+    >>> %snek phill
+
+    If a variable `params` already exists, you will be ask if you really want to
+    overwrite it. To skip this question:
+
+    >>> %snek phill -f
+
+    List all available solvers and initialized simulation:
+
+    >>> %snek
+
+    - Other fluidsim magic commands
+
+    Quick reference (print this help message):
+
+    >>> %fluidsim_help
+
+    Delete the objects `sim` and `params`:
+
+    >>> %fluidsim_reset
+
+    .. todo::
+
+        - Magic command %fluidsim_load
+
+        %fluidsim_load creates the variables `sim`, `params` and `Simul` from an
+        existing simulation.
+
+        Load existing simulation excluding state_phys files:
+
+        >>> %fluidsim_load
+
+        Load existing simulation all options: force overwrite, with state_phys
+        files, merging parameters:
+
+        >>> %fluidsim_load -f -s -t -m
+
+
+    """
+
+    entrypoint_grp = "snek5000.solvers"
+
+    @magic_arguments()
+    @argument("solver", nargs="?", default="")
+    @argument("-f", "--force-overwrite", action="store_true")
     @line_magic
-    def snek5000(self, line):
+    def snek(self, line):
         super().fluidsim(line)
 
 
 def load_ipython_extension(ipython):
     """Load the extension in IPython."""
-    logger.warning(
-        "Activating this magic involves dirty monkey-patching of fluidsim.magic"
-    )
-    magics = EturbMagics(ipython, "snek5000.solvers")
+    magics = SnekMagics(ipython)
     ipython.register_magics(magics)

--- a/src/snek5000/params.py
+++ b/src/snek5000/params.py
@@ -9,6 +9,7 @@ from io import StringIO
 from math import nan
 from pathlib import Path
 from sys import stdout
+from warnings import warn
 
 from fluidsim_core.params import Parameters as _Parameters
 from inflection import camelize, underscore
@@ -61,8 +62,8 @@ class Parameters(_Parameters):
         self._set_internal_attr("_user", True)
 
         if "path_file" in kwargs:
-            raise ValueError(
-                "Loading directly from path_file is not supported. Use "
+            warn(
+                "Loading directly from path_file is an experimental feature. Use "
                 "Simul.load_params_from_file() instead."
             )
 

--- a/src/snek5000/params.py
+++ b/src/snek5000/params.py
@@ -10,11 +10,8 @@ from math import nan
 from pathlib import Path
 from sys import stdout
 
-from fluiddyn.util import import_class
-from fluidsim.base.params import Parameters as _Parameters
+from fluidsim_core.params import Parameters as _Parameters
 from inflection import camelize, underscore
-
-from .info import InfoSolverBase
 
 literal_python2nek = {
     nan: "<real>",
@@ -199,31 +196,4 @@ class Parameters(_Parameters):
             self._set_doc(self._doc + textwrap.indent(docstring, " " * indent))
 
 
-def create_params(input_info_solver):
-    """Create a Parameters instance from an InfoSolverBase instance."""
-    if isinstance(input_info_solver, InfoSolverBase):
-        info_solver = input_info_solver
-    elif hasattr(input_info_solver, "Simul"):
-        info_solver = input_info_solver.Simul.create_default_params()
-    else:
-        raise ValueError("Can not create params from input input_info_solver.")
-
-    params = Parameters(tag="params")
-    dict_classes = info_solver.import_classes()
-
-    dict_classes["Solver"] = import_class(
-        info_solver.module_name, info_solver.class_name
-    )
-
-    for Class in list(dict_classes.values()):
-        if hasattr(Class, "_complete_params_with_default"):
-            try:
-                Class._complete_params_with_default(params)
-            except TypeError:
-                try:
-                    Class._complete_params_with_default(params, info_solver)
-                except TypeError as e:
-                    e.args += ("for class: " + repr(Class),)
-                    raise
-
-    return params
+create_params = Parameters._create_params

--- a/src/snek5000/solvers/__init__.py
+++ b/src/snek5000/solvers/__init__.py
@@ -8,22 +8,14 @@ Solver framework
    kth
 
 """
+from functools import partial
 
+from fluidsim_core import loader
 
-def available_solvers():
-    """Returns a dictionary of all registered solvers registered as an
-    entrypoint_.
+available_solvers = partial(loader.available_solvers, entrypoint_grp="snek5000.solvers")
+available_solvers.__doc__ = """\
+Returns a dictionary of all registered solvers registered as an entrypoint.
+"""
 
-    _entrypoint: https://packaging.python.org/guides/creating-and-discovering-plugins/#using-package-metadata
-
-    """
-    import entrypoints
-
-    return entrypoints.get_group_named("snek5000.solvers")
-
-
-def import_solver(name):
-    """Import the Simul class of a solver."""
-    solvers = available_solvers()
-    module = solvers[name].load()
-    return module.Simul
+import_cls_simul = partial(loader.import_cls_simul, entrypoint_grp="snek5000.solvers")
+import_cls_simul.__doc__ = """Import the Simul class of a solver."""

--- a/src/snek5000/solvers/base.py
+++ b/src/snek5000/solvers/base.py
@@ -208,6 +208,8 @@ class SimulNek(SimulCore):
                 self.path_run = Path(self.output.path_run)
                 if mpi.rank == 0:
                     self.output.copy(self.path_run)
+
+            self.output.post_init()
         else:
             par_file = None
             self.path_run = None

--- a/src/snek5000/solvers/base.py
+++ b/src/snek5000/solvers/base.py
@@ -9,15 +9,15 @@ from pathlib import Path
 from warnings import warn
 
 import numpy as np
-from fluidsim.base.solvers.base import SimulBase
-from fluidsim.base.solvers.info_base import create_info_simul
+from fluidsim_core.info import create_info_simul
+from fluidsim_core.solver import SimulCore
 
 from .. import __version__, logger, mpi
 from ..info import InfoSolverNek
-from ..params import Parameters, create_params
+from ..params import Parameters
 
 
-class SimulNek(SimulBase):
+class SimulNek(SimulCore):
     """Simulation class
 
     Parameters
@@ -37,6 +37,7 @@ class SimulNek(SimulBase):
     """
 
     InfoSolver = InfoSolverNek
+    Parameters = Parameters
 
     @classmethod
     def create_default_params(cls):
@@ -44,9 +45,7 @@ class SimulNek(SimulBase):
         parameters consumed by Nek5000.
 
         """
-        cls.info_solver = cls.InfoSolver()
-        cls.info_solver.complete_with_classes()
-        return create_params(cls.info_solver)
+        return super().create_default_params()
 
     @classmethod
     def load_params_from_file(cls, path_xml=None, path_par=None):

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1,12 +1,14 @@
 import pytest
+
 try:
     from IPython.testing.globalipapp import get_ipython
+
     ip = get_ipython()
-    ip.magic('load_ext snek5000.magic')
+    ip.magic("load_ext snek5000.magic")
 except ImportError:
     ip = False
 
 
 @pytest.mark.skipif(not ip, reason="Magics cannot be tested if IPython is unavailable")
 def test_snek5000_magic():
-    ip.run_line_magic('snek5000', 'kth')
+    ip.run_line_magic("snek", "kth")

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -51,10 +51,10 @@ def test_par_xml_match():
 
         nparams = Parameters(tag="params", path_file=params_xml)
     except ValueError:
-        # Should raise an error
+        # NOTE: used to raise an error, now testing experimentally
         pass
-    else:
-        raise ValueError("Parameters(path_file=...) worked unexpectedly.")
+    #  else:
+    #      raise ValueError("Parameters(path_file=...) worked unexpectedly.")
 
     nparams = Simul.load_params_from_file(path_xml=params_xml)
     output2 = StringIO()

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1,5 +1,5 @@
 from snek5000 import load_simul
-from snek5000.solvers import available_solvers, import_solver
+from snek5000.solvers import available_solvers, import_cls_simul
 
 
 def test_entrypoints():
@@ -26,7 +26,7 @@ def test_init_kth():
 def test_import_solver():
     from phill.solver import Simul
 
-    assert Simul is import_solver("phill")
+    assert Simul is import_cls_simul("phill")
     params = Simul.create_default_params()
     sim1 = Simul(params)
     sim2 = load_simul(sim1.path_run)


### PR DESCRIPTION
To fix:

```py
src/snek5000/params.py
13:from fluidsim_core.params import Parameters as _Parameters

src/snek5000/magic.py
9:   WARNING  Activating this magic involves dirty monkey-patching of fluidsim.magic
21:from fluidsim import magic as fluidsim_magic
42:fluidsim_magic.available_solver_keys = available_solver_keys
43:fluidsim_magic.import_simul_class_from_key = import_simul_class_from_key
47:class EturbMagics(fluidsim_magic.FluidsimMagics):
53:        super().fluidsim(line)
59:        "Activating this magic involves dirty monkey-patching of fluidsim.magic"

src/snek5000/info.py
8:from fluidsim.base.solvers.info_base import InfoSolverBase

src/snek5000/solvers/base.py
12:from fluidsim.base.solvers.base import SimulBase
13:from fluidsim.base.solvers.info_base import create_info_simul

src/snek5000/output/base.py
13:from fluidsim.base.output.base import OutputBase
```