### PR TITLE
No need to wait for {config['CASE']}.f (this file is actually deleted by Nek5000)

### DIFF
--- a/src/snek5000/assets/compiler.smk
+++ b/src/snek5000/assets/compiler.smk
@@ -42,7 +42,6 @@ rule compile:
     params:
         make="make",
     output:
-        f"{config['CASE']}.f",
         exe="nek5000",
     shell:
         """


### PR DESCRIPTION
(by Nek5000 master)

Fix #39 