### PR TITLE
Flexible nproc

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ sim = Simul(params)
 sim.make.exec()  # by default starts a run
 sim.make.exec(["mesh", "compile"])  # run rules in order
 sim.make.exec(["run"], dryrun=True)  # simulate simulation
-sim.make.exec(["run"])  # actual simulation
+sim.make.exec(["run"], resources={"nproc": 2})  # actual simulation
 ```
 
 Check out the

--- a/docs/ipynb/executed/tuto_simul.ipynb
+++ b/docs/ipynb/executed/tuto_simul.ipynb
@@ -309,6 +309,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Execute the simulation\n",
+    "\n",
     "To run the simulation we need to execute certain commands. These are described using snakemake in the Snakefile. Let's look at the rules defined in the Snakefile (which are nearly generic for any Nek5000 case)."
    ]
   },
@@ -364,7 +366,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The rules in the Snakefile are either shell commands or Python code which handle different parts of the build step, such as building a mesh (rule `mesh`), compiling (rule `compile`) and running the simulation (rule `run` or `srun`). The rules can be executed on by one by passing them as strings to the `exec` method of the `sim.make` object. The default parameter is to do everyting to run a simulation."
+    "The rules in the Snakefile are either shell commands or Python code which handle different parts of the build step, such as building a mesh (rule `mesh`), compiling (rule `compile`) and running the simulation (rule `run` or `run_fg`). The rules can be executed on by one by passing them as strings to the [exec](snek5000.make.Make.exec) method of the `sim.make` object. The default parameter is to do everyting to run a simulation."
    ]
   },
   {
@@ -375,11 +377,24 @@
     {
      "data": {
       "text/plain": [
-       "\u001b[0;31mSignature:\u001b[0m \u001b[0msim\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmake\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexec\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mrules\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'run'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdryrun\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mSignature:\u001b[0m \u001b[0msim\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmake\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexec\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mrules\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'run'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdryrun\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
        "\u001b[0;31mDocstring:\u001b[0m\n",
        "Execute snakemake rules in sequence.\n",
        "\n",
+       ":param iterable rules: Snakemake rules to be executed\n",
+       ":param bool dryrun: Dry run snakemake without executing\n",
+       "\n",
+       "For more on available keyword arguments refer to `snakemake API documentation`_.\n",
+       "\n",
        ":returns: True if workflow execution was successful.\n",
+       "\n",
+       ".. _snakemake API documentation: https://snakemake.readthedocs.io/en/stable/api_reference/snakemake.html\n",
+       "\n",
+       "Examples\n",
+       "--------\n",
+       "\n",
+       ">>> sim.make.exec(['compile'])\n",
+       ">>> sim.make.exec(['run'], resources={'nproc': 4})\n",
        "\u001b[0;31mFile:\u001b[0m      ~/src/snek5000/snek5000/src/snek5000/make.py\n",
        "\u001b[0;31mType:\u001b[0m      method\n"
       ]

--- a/src/snek5000/__init__.py
+++ b/src/snek5000/__init__.py
@@ -8,6 +8,7 @@ A Pythonic frontend to Nek5000.
    :toctree:
 
    assets
+   clusters
    output
    solvers
    util

--- a/src/snek5000/assets/compiler.smk
+++ b/src/snek5000/assets/compiler.smk
@@ -82,7 +82,7 @@ use rule mpiexec as run with:
 
 
 # run in foreground
-use rule mpiexec as srun with:
+use rule mpiexec as run_fg with:
     params:
         redirect="| tee",
         end="",

--- a/src/snek5000/assets/compiler.smk
+++ b/src/snek5000/assets/compiler.smk
@@ -1,6 +1,7 @@
 from pprint import pprint
 
 import snek5000
+from snek5000.clusters import nproc_available
 from snek5000.util import now
 
 
@@ -59,8 +60,9 @@ rule mpiexec:
         "nek5000",
     log:
         "logs/run_" + now() + ".log",
+    resources:
+        nproc=nproc_available(),
     params:
-        nproc=str(os.cpu_count()),
         redirect=">",
         end="",
     shell:
@@ -68,14 +70,13 @@ rule mpiexec:
         ln -sf {log} {config[CASE]}.log
         echo "Log file:"
         realpath {config[CASE]}.log
-        {config[MPIEXEC]} -n {params.nproc} ./nek5000 {params.redirect} {log} {params.end}
+        {config[MPIEXEC]} -n {resources.nproc} ./nek5000 {params.redirect} {log} {params.end}
         """
 
 
 # run in background
 use rule mpiexec as run with:
     params:
-        nproc=str(os.cpu_count()),
         redirect=">",
         end="&",
 
@@ -83,6 +84,5 @@ use rule mpiexec as run with:
 # run in foreground
 use rule mpiexec as srun with:
     params:
-        nproc=str(os.cpu_count()),
         redirect="| tee",
         end="",

--- a/src/snek5000/clusters.py
+++ b/src/snek5000/clusters.py
@@ -1,33 +1,24 @@
-try:
-    from fluiddyn.clusters.snic import ClusterSNIC as Base, _venv
+"""Cluster utilities"""
+import os
 
-    class Cluster(Base):
-        default_project = "snic2020-1-31"
-        cmd_run = "_delete"
-        cmd_run_interactive = "_delete"
-
-        def __init__(self):
-            super().__init__()
-            self.commands_setting_env = [
-                "ml purge",
-                "ml restore",
-                f"source activate {_venv}",
-                'export LD_LIBRARY_PATH="$LD_LIBRARY_PATH":"$LIBRARY_PATH"',
-                "cd ..",
-                "source activate.sh",
-                "cd bin/",
-            ]
-
-        def _create_txt_launching_script(self, **kwargs):
-            txt = super()._create_txt_launching_script(**kwargs)
-            return "\n".join(
-                [line for line in txt.splitlines() if not line.startswith("_delete")]
-            )
+from .log import logger
 
 
-except ImportError as e:
-    from .log import logger
+def nproc_available():
+    """Detect maximum number of processors available"""
 
-    logger.warning(str(e))
-    logger.info("Using local machine as a cluster")
-    from fluiddyn.clusters.local import ClusterLocal as Cluster  # noqa
+    # Inside job schedulers, number of processors assigened will vary
+    # TODO: extend this loop for other schedulers OAR, PBS etc.
+    for var in ("SLURM_NPROCS",):
+        try:
+            nproc = os.environ[var]
+        except KeyError:
+            continue
+        else:
+            break
+    else:
+        var = "os.cpu_count()"
+        nproc = os.cpu_count()
+
+    logger.info(f"Using {var} to detect maximum number of processors available")
+    return nproc

--- a/src/snek5000/make.py
+++ b/src/snek5000/make.py
@@ -36,17 +36,30 @@ class Make:
         :param iterable rules: Snakemake rules to be executed
         :param bool dryrun: Dry run snakemake without executing
 
-        For more on available keyword arguments refer to `snakemake API documentation`_.
+        For more on available keyword arguments refer to `Snakemake API documentation`_.
 
         :returns: True if workflow execution was successful.
 
-        .. _snakemake API documentation: https://snakemake.readthedocs.io/en/stable/api_reference/snakemake.html
+        .. _Snakemake API documentation: https://snakemake.readthedocs.io/en/stable/api_reference/snakemake.html
 
         Examples
         --------
 
         >>> sim.make.exec(['compile'])
         >>> sim.make.exec(['run'], resources={'nproc': 4})
+
+        It is also possible to do the same directly from command line
+        by changing to the simulation directory and executing::
+
+            snakemake -j compile
+            snakemake -j1 --resources nproc=2 run
+
+        The flag ``-j`` is short for ``--jobs`` and sets the number of
+        threads available for snakemake rules to execute.
+
+        .. seealso:: Useful Snakemake `command line arguments`_
+
+        .. _command line arguments: https://snakemake.readthedocs.io/en/stable/executing/cli.html#useful-command-line-arguments
 
         """
         with change_dir(self.path_run):

--- a/src/snek5000/make.py
+++ b/src/snek5000/make.py
@@ -33,7 +33,20 @@ class Make:
     def exec(self, rules=("run",), dryrun=False, **kwargs):
         """Execute snakemake rules in sequence.
 
+        :param iterable rules: Snakemake rules to be executed
+        :param bool dryrun: Dry run snakemake without executing
+
+        For more on available keyword arguments refer to `snakemake API documentation`_.
+
         :returns: True if workflow execution was successful.
+
+        .. _snakemake API documentation: https://snakemake.readthedocs.io/en/stable/api_reference/snakemake.html
+
+        Examples
+        --------
+
+        >>> sim.make.exec(['compile'])
+        >>> sim.make.exec(['run'], resources={'nproc': 4})
 
         """
         with change_dir(self.path_run):


### PR DESCRIPTION
- Add nproc_available, nproc as resources for run
- Rename srun rule to run_fg
- Update tutorial

TODO: Either:

- add environment variable equivalent to `SLURM_NPROS`, or
- find a better way to detect number of available processors (as in [fluidimage](https://foss.heptapod.net/fluiddyn/fluidimage/-/blob/branch/default/fluidimage/topologies/nb_cpu_cores.py)?)

Fixes: #41 
