### PR TITLE
Relative SESSION.NAME and multiple sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Security in case of vulnerabilities.
 
 ### Added
 
-- {func}`snek5000.util.restart.load_for_restart` function
+- Functions {func}`snek5000.util.restart.load_for_restart`, {func}`snek5000.params.load_params`
 - {mod}`snek5000.util.files`
 - {meth}`snek5000.output.base.Output.get_field_file` to locate a field file
 - Mandatory key `MPIEXEC_FLAGS` in Snakemake config
@@ -42,9 +42,13 @@ Security in case of vulnerabilities.
   staggered grid if a linear solver is used and a collocated one if some other
   solver is used. Explicitly setting `params.oper.elem.staggered = True` is
   required to maintain previous default behaviour.
-- {func}`snek5000.util.files.next_path` gets a `force_suffix` parameter
+- {func}`snek5000.util.files.next_path` gets `force_suffix` and `return_suffix`
+  parameters
 - {meth}`snek5000.output.base.Output._save_info_solver_params_xml` updates
-  `.par` file on loading for restart
+  `.par` and `params_simul.xml` file on loading for restart
+- Shorter output while executing `genmap`
+- Field files will be stored in sessions enabling restart with symlinking of
+  restart files and avoids clobbering existing solution files
 
 ### Deprecated
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -35,7 +35,7 @@ intersphinx-jinja2:
 	@python -msphinx.ext.intersphinx https://jinja.palletsprojects.com/en/2.10.x/objects.inv
 
 autobuild:
-	@sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)/html"
+	@sphinx-autobuild --watch ../src --ignore _build/jupyter_execute "$(SOURCEDIR)" "$(BUILDDIR)/html"
 
 cleanall: clean
 	@echo "Removing everything under '_generated'..."

--- a/docs/html_theme_options.py
+++ b/docs/html_theme_options.py
@@ -1,7 +1,12 @@
+__common_css_variables = {
+    "font-size--small--2": "84%",
+}
 light_css_variables = {
     "color-brand-primary": "#1954a6",
     "color-brand-content": "#1954a6",
+    **__common_css_variables,
 }
+dark_css_variables = {**__common_css_variables}
 
 #  # Material theme options (see theme.conf for more information)
 #  html_theme_options = {

--- a/src/snek5000/assets/internal.smk
+++ b/src/snek5000/assets/internal.smk
@@ -1,4 +1,5 @@
 import snek5000
+from snek5000.util.files import create_session
 
 
 NEK_SOURCE_ROOT = snek5000.source_root()
@@ -71,11 +72,11 @@ rule generate_makefile:
 
 # generate sessionfile
 rule generate_session:
+    input:
+        re2=f"{config['CASE']}.re2",
+        ma2=f"{config['CASE']}.ma2",
+        par=f"{config['CASE']}.par",
     output:
         "SESSION.NAME",
-    shell:
-        """
-        touch SESSION.NAME
-        echo {config[CASE]} > SESSION.NAME
-        echo `pwd`'/' >>  SESSION.NAME
-        """
+    run:
+        create_session(config["CASE"], input.re2, input.ma2, input.par)

--- a/src/snek5000/assets/internal.smk
+++ b/src/snek5000/assets/internal.smk
@@ -41,11 +41,12 @@ rule generate_map:
         genmap=Nek5000("bin/genmap"),
     output:
         f"{config['CASE']}.ma2",
-    params:
-        tolerance=0.01,
+    resources:
+        tolerance="0.01",
     shell:
-        'echo "{config[CASE]}\n{params.tolerance}" | '
-        "{input.genmap}"
+        r'printf "{config[CASE]}\n{resources.tolerance}\n" '
+        "  | {input.genmap} "
+        "  | (head -n 20; tail -n 10) "
 
 
 # generate makefile

--- a/src/snek5000/output/__init__.py
+++ b/src/snek5000/output/__init__.py
@@ -10,3 +10,15 @@ Manage outputs
 
 
 """
+from pathlib import Path
+
+
+def _make_path_session(path_run: str, session_id: int):
+    """Create a path object pointing to session directory.
+
+    Parameters
+    ----------
+    path_run : str
+    session_id : int
+    """
+    return Path(path_run) / f"session_{session_id:02d}"

--- a/src/snek5000/output/base.py
+++ b/src/snek5000/output/base.py
@@ -314,6 +314,9 @@ class Output(OutputCore):
         path_session: path-like
 
         """
+        if not self.params:
+            return None
+
         try:
             session_id = self.params.session_id
         except AttributeError:

--- a/src/snek5000/output/base.py
+++ b/src/snek5000/output/base.py
@@ -20,6 +20,8 @@ from snek5000.solvers import get_solver_package, is_package
 from snek5000.util import docstring_params
 from snek5000.util.smake import append_debug_flags
 
+from . import _make_path_session
+
 
 class Output(OutputCore):
     """Container and methods for getting paths of and copying case files.
@@ -327,7 +329,7 @@ class Output(OutputCore):
                 "Attribute sim.output.path_session is set as sim.output.path_run."
             )
         else:
-            path_session = Path(self.path_run) / f"session_{session_id:02d}"
+            path_session = _make_path_session(self.path_run, session_id)
 
         self.params._set_attrib("path_session", path_session)
 

--- a/src/snek5000/output/base.py
+++ b/src/snek5000/output/base.py
@@ -7,6 +7,7 @@ import os
 import pkgutil
 import shutil
 import stat
+import textwrap
 from itertools import chain
 from pathlib import Path
 from socket import gethostname
@@ -16,6 +17,7 @@ from inflection import underscore
 
 from snek5000 import __version__, get_asset, logger, mpi, resources
 from snek5000.solvers import get_solver_package, is_package
+from snek5000.util import docstring_params
 from snek5000.util.smake import append_debug_flags
 
 
@@ -96,12 +98,25 @@ class Output(OutputCore):
         """This static method is used to complete the *params* container."""
         # Bare minimum
         attribs = {
-            "ONLINE_PLOT_OK": True,
-            "period_refresh_plots": 1,
             "HAS_TO_SAVE": True,
             "sub_directory": "",
+            "session_id": 0,
         }
         params._set_child("output", attribs=attribs)
+        params.output._set_doc(
+            textwrap.dedent(
+                """
+    - ``HAS_TO_SAVE``: bool (default: True) If False, nothing new is saved in
+      the directory of the simulation.
+    - ``sub_directory``: str (default: "") A name of a sub-directory (relative
+      to $FLUIDDYN_PATH_SCRATCH) wherein the directory of the simulation
+      (``path_run``) is saved.
+    - ``session_id``: int (default: 0) Determines the sub-directory (relative
+      to ``path_run``) in which the field files would be generated during
+      runtime. The session directory takes the form `session_{session_id}`.
+"""
+            )
+        )
 
     @classmethod
     def get_root(cls):
@@ -591,3 +606,18 @@ class Output(OutputCore):
                     params.nek._write_par(fp)
 
         super()._save_info_solver_params_xml(replace, comment=f"snek5000 {__version__}")
+
+
+Output.__doc__ += """
+    Notes
+    -----
+    Here, only the documention for ``params.output`` is displayed.
+
+    .. seealso::
+
+        - ``params.oper`` at :mod:`snek5000.operators`
+        - ``params.nek`` at :mod:`snek5000.solvers.base`
+
+""" + docstring_params(
+    Output
+)

--- a/src/snek5000/params.py
+++ b/src/snek5000/params.py
@@ -13,6 +13,8 @@ from sys import stdout
 from fluidsim_core.params import Parameters as _Parameters
 from inflection import camelize, underscore
 
+from .solvers import get_solver_short_name, import_cls_simul
+
 literal_python2nek = {
     nan: "<real>",
     "nan": "nan",
@@ -31,6 +33,28 @@ def camelcase(value):
 def _check_user_param(idx):
     if idx > 20:
         raise ValueError(f"userParam {idx} > 20")
+
+
+def load_params(path_dir="."):
+    """Load a :class:`snek5000.params.Parameters` instance from `path_dir`.
+
+    Parameters
+    ----------
+    path_dir : str or path-like
+        Path to a simulation directory.
+
+    Returns
+    -------
+    params: :class:`snek5000.params.Parameters`
+
+    """
+    path_dir = Path(path_dir)
+    short_name = get_solver_short_name(path_dir)
+    Simul = import_cls_simul(short_name)
+
+    return Simul.load_params_from_file(
+        path_xml=path_dir / "params_simul.xml", path_par=path_dir / f"{short_name}.par"
+    )
 
 
 class Parameters(_Parameters):

--- a/src/snek5000/solvers/__init__.py
+++ b/src/snek5000/solvers/__init__.py
@@ -10,6 +10,7 @@ Solver framework
 """
 import importlib
 from functools import partial
+from pathlib import Path
 from pkgutil import ModuleInfo
 from types import ModuleType
 
@@ -99,3 +100,25 @@ def get_solver_short_name(path_dir):
         short_name = path_dir.absolute().name.split("_")[0]
 
     return short_name
+
+
+def load_params(path_dir="."):
+    """Load a :class:`snek5000.params.Parameters` instance from `path_dir`.
+
+    Parameters
+    ----------
+    path_dir : str or path-like
+        Path to a simulation directory.
+
+    Returns
+    -------
+    params: :class:`snek5000.params.Parameters`
+
+    """
+    path_dir = Path(path_dir)
+    short_name = get_solver_short_name(path_dir)
+    Simul = import_cls_simul(short_name)
+
+    return Simul.load_params_from_file(
+        path_xml=path_dir / "params_simul.xml", path_par=path_dir / f"{short_name}.par"
+    )

--- a/src/snek5000/solvers/__init__.py
+++ b/src/snek5000/solvers/__init__.py
@@ -10,7 +10,6 @@ Solver framework
 """
 import importlib
 from functools import partial
-from pathlib import Path
 from pkgutil import ModuleInfo
 from types import ModuleType
 
@@ -100,25 +99,3 @@ def get_solver_short_name(path_dir):
         short_name = path_dir.absolute().name.split("_")[0]
 
     return short_name
-
-
-def load_params(path_dir="."):
-    """Load a :class:`snek5000.params.Parameters` instance from `path_dir`.
-
-    Parameters
-    ----------
-    path_dir : str or path-like
-        Path to a simulation directory.
-
-    Returns
-    -------
-    params: :class:`snek5000.params.Parameters`
-
-    """
-    path_dir = Path(path_dir)
-    short_name = get_solver_short_name(path_dir)
-    Simul = import_cls_simul(short_name)
-
-    return Simul.load_params_from_file(
-        path_xml=path_dir / "params_simul.xml", path_par=path_dir / f"{short_name}.par"
-    )

--- a/src/snek5000/solvers/base.py
+++ b/src/snek5000/solvers/base.py
@@ -58,14 +58,14 @@ class SimulNek(SimulCore):
                 "Either path to params_simul.xml or case.par should be provided"
             )
 
-        params = Parameters(tag="params")
         if path_xml:
+            params = Parameters(tag="params")
             params._load_from_xml_file(str(path_xml))
         else:
-            # FIXME: or remove, because it no longer works
             logger.warn(
                 "Loading from a par file will not have full details of the simulation"
             )
+            params = cls.create_default_params()
             params.nek._read_par(path_par)
 
         cls._set_internal_sections(params)

--- a/src/snek5000/solvers/base.py
+++ b/src/snek5000/solvers/base.py
@@ -60,8 +60,9 @@ class SimulNek(SimulCore):
 
         params = Parameters(tag="params")
         if path_xml:
-            params._load_from_xml_file(path_xml)
+            params._load_from_xml_file(str(path_xml))
         else:
+            # FIXME: or remove, because it no longer works
             logger.warn(
                 "Loading from a par file will not have full details of the simulation"
             )

--- a/src/snek5000/util/__init__.py
+++ b/src/snek5000/util/__init__.py
@@ -143,7 +143,14 @@ def init_params(Class, isolated_unit=False):
         from ..params import Parameters
 
         params = Parameters(tag="params")
-        Class._complete_params_with_default(params)
+        try:
+            Class._complete_params_with_default(params)
+        except TypeError:
+            from snek5000.info import InfoSolverMake
+
+            info_solver = InfoSolverMake()
+
+            Class._complete_params_with_default(params, info_solver)
 
     return params
 

--- a/src/snek5000/util/files.py
+++ b/src/snek5000/util/files.py
@@ -6,7 +6,7 @@ from .. import logger
 from ..solvers import load_params
 
 
-def next_path(old_path, force_suffix=False):
+def next_path(old_path, force_suffix=False, return_suffix=False):
     """Generate a new path with an integer suffix
 
     Parameters
@@ -18,8 +18,14 @@ def next_path(old_path, force_suffix=False):
         If true, will not check if the `old_path` can be used and adds
         a suffix in the end.
 
+    return_suffix:
+        If true, returns the integer suffix along with the path/
+
     Returns
     -------
+    (i, new_path): tuple[int, Path]
+        If `return_suffix` is `True`.
+
     new_path: Path
         A path (with an integer suffix) which does not yet exist in the
         filesystem.
@@ -71,7 +77,7 @@ def next_path(old_path, force_suffix=False):
 
     logger.debug(f"Next path available: {new_path}")
 
-    return new_path
+    return (i, new_path) if return_suffix else new_path
 
 
 def create_session(case, re2, ma2, par):

--- a/src/snek5000/util/files.py
+++ b/src/snek5000/util/files.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from shutil import copy2
 
 from .. import logger
-from ..solvers import load_params
+from ..params import load_params
 
 
 def next_path(old_path, force_suffix=False, return_suffix=False):

--- a/src/snek5000/util/files.py
+++ b/src/snek5000/util/files.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from shutil import copy2
 
 from .. import logger
+from ..solvers import load_params
 
 
 def next_path(old_path, force_suffix=False):
@@ -74,7 +75,7 @@ def next_path(old_path, force_suffix=False):
 
 
 def create_session(case, re2, ma2, par):
-    """Creates a new session and write the path to a `SESSION.NAME` file.
+    """Creates a session and write the path to a `SESSION.NAME` file.
     Then, symlinks re2 and ma2 files, and copies the par file.
 
     Parameters
@@ -88,14 +89,10 @@ def create_session(case, re2, ma2, par):
     par : str
         Parameter file name
 
-    .. todo::
-
-        Adapt load_for_restart function
-
     """
-    session_dir = next_path("session", force_suffix=True)
+    session_dir = load_params().output.path_session
 
-    session_dir.mkdir()
+    session_dir.mkdir(exists_ok=True)
 
     with open("SESSION.NAME", "w") as session_name:
         # use relative paths to avoid 132 character limit in Nek5000

--- a/src/snek5000/util/files.py
+++ b/src/snek5000/util/files.py
@@ -71,9 +71,9 @@ def next_path(old_path, force_suffix=False, return_suffix=False):
     new_path = int_suffix(old_path, i)
 
     while new_path.exists():
-        logger.debug(f"Checking if path exists: {new_path}")
-        new_path = int_suffix(old_path, i)
+        logger.debug(f"Path exists: {new_path}")
         i += 1
+        new_path = int_suffix(old_path, i)
 
     logger.debug(f"Next path available: {new_path}")
 
@@ -96,13 +96,14 @@ def create_session(case, re2, ma2, par):
         Parameter file name
 
     """
-    session_dir = load_params().output.path_session
+    params = load_params()
+    session_dir = Path(params.output.path_session).relative_to(params.path_run)
 
-    session_dir.mkdir(exists_ok=True)
+    session_dir.mkdir(exist_ok=True)
 
     with open("SESSION.NAME", "w") as session_name:
         # use relative paths to avoid 132 character limit in Nek5000
-        session_name.write(f"{case}\n" f"./{session_dir}")
+        session_name.write(f"{case}\n./{session_dir}\n")
 
     for file in (re2, ma2):
         # use relative symlinks

--- a/src/snek5000/util/restart.py
+++ b/src/snek5000/util/restart.py
@@ -221,6 +221,8 @@ def load_for_restart(
         params.output.session_id = session_id
         params.output.path_session = new_path_session
 
+        new_path_session.mkdir()
+
     def make_relative_symlink(file_name):
         src = new_path_session / file_name
         dest = f"../{old_path_session.name}/{file_name}"

--- a/src/snek5000/util/restart.py
+++ b/src/snek5000/util/restart.py
@@ -186,7 +186,11 @@ def load_for_restart(
         logger.info("Trying to open the path relative to $FLUIDSIM_PATH")
         path = Path(FLUIDSIM_PATH) / path_dir
 
-    params = load_params(path)
+    try:
+        params = load_params(path)
+    except (ValueError, OSError) as err:
+        raise SnekRestartError(err)
+
     status = get_status(path, params.output.session_id)
 
     if verify_contents:

--- a/src/snek5000/util/restart.py
+++ b/src/snek5000/util/restart.py
@@ -10,7 +10,7 @@ from warnings import warn
 from fluiddyn.io import FLUIDSIM_PATH
 
 from ..log import logger
-from ..solvers import get_solver_short_name, import_cls_simul
+from ..solvers import get_solver_short_name, import_cls_simul, load_params
 
 
 class SnekRestartError(Exception):
@@ -171,7 +171,6 @@ def load_for_restart(
         Possibility to make a new session
 
     """
-    contents = os.listdir(path_dir)
     path = Path(path_dir)
     if not path.exists():
         logger.info("Trying to open the path relative to $FLUIDSIM_PATH")
@@ -193,16 +192,7 @@ def load_for_restart(
     except ImportError:
         raise ImportError(f"Cannot import Simul class of solver {short_name}")
 
-    if "params_simul.xml" in contents:
-        params = Simul.load_params_from_file(path_xml=str(path / "params_simul.xml"))
-    else:
-        # Trying to read the par file
-        logger.warning(
-            f"No params_simul.xml found... Attempting to read {short_name}.par"
-        )
-
-        params = Simul.create_default_params()
-        params.nek._read_par(path / f"{short_name}.par")
+    params = load_params(path)
 
     # Set restart file
     if use_start_from and use_checkpoint:

--- a/src/snek5000/util/restart.py
+++ b/src/snek5000/util/restart.py
@@ -11,7 +11,8 @@ from fluiddyn.io import FLUIDSIM_PATH
 
 from ..log import logger
 from ..output import _make_path_session
-from ..solvers import get_solver_short_name, import_cls_simul, load_params
+from ..params import load_params
+from ..solvers import get_solver_short_name, import_cls_simul
 from .files import next_path
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,13 +16,14 @@ def pytest_configure(config):
 
     try:
         import rich  # noqa
+
+        import snek5000.log
+
     except ImportError:
         pass
     else:
         # Bug while using rich + pytest: stderr / stdout is too short
         # Inspired from: https://github.com/willmcgugan/rich/issues/1425
-        import snek5000.log
-
         snek5000.log.logger.removeHandler(snek5000.log.handler)
 
         handler = snek5000.log.create_handler(width=shutil.get_terminal_size().columns)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,7 +141,6 @@ def sim_data(tmpdir_factory):
 makefile
 makefile_usr.inc
 nek5000
-phill0.f00001
 phill.box
 phill.f
 phill.log
@@ -149,16 +148,30 @@ phill.ma2
 phill.par
 phill.re2
 phill.usr
-rs6phill0.f00001
-rs6phill0.f00002
-rs6phill0.f00003
 SESSION.NAME
 SIZE
 Snakefile""".splitlines()
 
+    session_files = """
+phill0.f00001
+rs6phill0.f00001
+rs6phill0.f00002
+rs6phill0.f00003
+""".splitlines()
+
     path_run = Path(tmpdir_factory.mktemp("phill_sim_data"))
+
+    from snek5000.output import _make_path_session
+
+    session_id = 0
+    path_session = _make_path_session(path_run, session_id)
+    path_session.mkdir()
+
     for f in files:
         (path_run / f).touch()
+
+    for f in session_files:
+        (path_session / f).touch()
 
     from phill.solver import Simul
 
@@ -167,6 +180,8 @@ Snakefile""".splitlines()
 
     info._save_as_xml(path_run / "info_solver.xml")
     params._set_attrib("path_run", path_run)
+    params.output._set_attrib("session_id", session_id)
+    params.output._set_attrib("path_session", path_session)
     params._save_as_xml(path_run / "params_simul.xml")
 
     return path_run

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from snek5000.util import files
@@ -64,7 +65,23 @@ def test_next_path_dir(tmpdir):
     tmpdir = Path(tmpdir)
 
     target = tmpdir / "test_dir"
+    path_dir = files.next_path(target, force_suffix=True)
 
-    assert str(files.next_path(target, force_suffix=True)) == str(
-        tmpdir / "test_dir_00"
-    )
+    assert str(path_dir) == str(tmpdir / "test_dir_00")
+
+
+def test_next_path_relative(tmpdir):
+    os.chdir(tmpdir)
+
+    session_00 = Path("./session_00")
+    session_01 = Path("./session_01")
+
+    assert files.next_path("session", force_suffix=True) == session_00
+
+    session_00.mkdir()
+    session_dir = files.next_path("session", force_suffix=True)
+
+    assert session_dir == session_01
+
+    if session_dir.is_absolute():
+        raise ValueError("next_path should return a relative path")

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -79,8 +79,11 @@ def test_next_path_relative(tmpdir):
     assert files.next_path("session", force_suffix=True) == session_00
 
     session_00.mkdir()
-    session_dir = files.next_path("session", force_suffix=True)
+    int_suffix, session_dir = files.next_path(
+        "session", force_suffix=True, return_suffix=True
+    )
 
+    assert int_suffix == 1
     assert session_dir == session_01
 
     if session_dir.is_absolute():

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -49,8 +49,10 @@ def test_partial_content(sim_data):
     assert get_status(sim_data).code == 206
 
 
-def test_restart_error(tmpdir):
-    with pytest.raises(SnekRestartError, match="425: Too Early"):
+@pytest.mark.parametrize("prefix_dir", ("phill_", "undefined_solver"))
+def test_restart_error(tmpdir_factory, prefix_dir):
+    tmpdir = tmpdir_factory.mktemp(prefix_dir)
+    with pytest.raises(SnekRestartError):
         load_for_restart(tmpdir)
 
 

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -2,7 +2,7 @@ import pymech as pm
 import pytest
 
 from snek5000.output import _make_path_session
-from snek5000.solvers import load_params
+from snek5000.params import load_params
 from snek5000.util.restart import SnekRestartError, get_status, load_for_restart
 
 

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -2,6 +2,7 @@ import pymech as pm
 import pytest
 
 from snek5000.output import _make_path_session
+from snek5000.solvers import load_params
 from snek5000.util.restart import SnekRestartError, get_status, load_for_restart
 
 
@@ -79,3 +80,7 @@ def test_restart(sim_executed):
 
     fld = pm.readnek(sim.output.get_field_file())
     assert fld.time == t_end
+
+    # check if params_simul.xml is updated
+    params_in_filesystem = load_params(sim_executed.path_run)
+    assert params.output.session_id == params_in_filesystem.output.session_id

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -1,6 +1,7 @@
 import pymech as pm
 import pytest
 
+from snek5000.output import _make_path_session
 from snek5000.util.restart import SnekRestartError, get_status, load_for_restart
 
 
@@ -21,7 +22,8 @@ def test_locked(sim_data):
 
 def test_ok(sim_data):
     (sim_data / ".snakemake").mkdir()
-    [file.unlink() for file in sim_data.glob("phill*0.f?????")]
+    session = _make_path_session(sim_data, 0)
+    [file.unlink() for file in session.glob("phill*0.f?????")]
 
     assert get_status(sim_data).code == 200
 
@@ -41,7 +43,8 @@ def test_not_found(sim_data):
 
 def test_partial_content(sim_data):
     (sim_data / ".snakemake").mkdir()
-    [restart.unlink() for restart in sim_data.glob("rs6*")]
+    session = _make_path_session(sim_data, 0)
+    [restart.unlink() for restart in session.glob("rs6*")]
 
     assert get_status(sim_data).code == 206
 


### PR DESCRIPTION
Fixes #65 

- SESSION.NAME will contain relative paths
- When any of the input files are varied (.re2, .ma2, .par), typically via `load_for_restart` a new session will be created