### PR TITLE
Allow choosing session_id in load_simul and load_for_restart

### DIFF
--- a/src/snek5000/__init__.py
+++ b/src/snek5000/__init__.py
@@ -101,15 +101,13 @@ def load_simul(path_dir=".", session_id=None):
 
     # Load simulation class
     from snek5000.solvers import import_cls_simul, get_solver_short_name
+    from snek5000.output import _parse_path_run_session_id
+
+    # In case the user specifies the path to a session sub-directory
+    if session_id is None:
+        path_dir, session_id = _parse_path_run_session_id(path_dir)
 
     short_name = get_solver_short_name(path_dir)
-    if short_name == "session" and not (path_dir / "info_solver.xml").exists():
-        raise ValueError(
-            "You are trying to specify the path to a session sub-directory. "
-            "Specify the main simulation directory instead and "
-            "the session_id (optional)."
-        )
-
     Simul = import_cls_simul(short_name)
 
     # Load parameters

--- a/src/snek5000/__init__.py
+++ b/src/snek5000/__init__.py
@@ -102,7 +102,15 @@ def load_simul(path_dir=".", session_id=None):
     # Load simulation class
     from snek5000.solvers import import_cls_simul, get_solver_short_name
 
-    Simul = import_cls_simul(get_solver_short_name(path_dir))
+    short_name = get_solver_short_name(path_dir)
+    if short_name == "session" and not (path_dir / "info_solver.xml").exists():
+        raise ValueError(
+            "You are trying to specify the path to a session sub-directory. "
+            "Specify the main simulation directory instead and "
+            "the session_id (optional)."
+        )
+
+    Simul = import_cls_simul(short_name)
 
     # Load parameters
     from snek5000.params import load_params

--- a/src/snek5000/__init__.py
+++ b/src/snek5000/__init__.py
@@ -70,7 +70,7 @@ def get_asset(asset_name):
     return asset
 
 
-def load_simul(path_dir=None):
+def load_simul(path_dir=".", session_id=None):
     """Loads a simulation
 
     .. todo::
@@ -80,15 +80,24 @@ def load_simul(path_dir=None):
     Parameters
     ----------
     path_dir: str or path-like
-
         Path to a directory containing a simulation. If not provided the
         current directory is used.
 
+    session_id: int
+        Indicate which session directory should be used to set
+        ``sim.output.path_session``. If not specified it would default to the
+        `session_id` and `path_session` values last recorded in the
+        `params_simul.xml` file
+
+
+    .. hint::
+
+        An common use case of ``session_id`` parameter is to load field
+        files from old sessions using the :meth:`sim.output.get_field_file
+        <snek5000.output.base.Output.get_field_file>` method
+
     """
-    if path_dir is None:
-        path_dir = Path.cwd()
-    else:
-        path_dir = Path(path_dir)
+    path_dir = Path(path_dir)
 
     # Load simulation class
     from snek5000.solvers import import_cls_simul, get_solver_short_name
@@ -96,22 +105,21 @@ def load_simul(path_dir=None):
     Simul = import_cls_simul(get_solver_short_name(path_dir))
 
     # Load parameters
-    from snek5000.params import Parameters
+    from snek5000.params import load_params
 
-    params = Parameters._load_params_simul(path_dir)
+    params = load_params(path_dir)
 
-    # try:
-    #     params_par = next(path_dir.glob("*.par"))
-    # except StopIteration:
-    #     warn(f"The {path_dir}/*.par file is missing!")
-    #     params_par = None
-    #
-    # params_xml = path_dir / "params_simul.xml"
-    # params = Simul.load_params_from_file(path_xml=params_xml, path_par=params_par)
     # Modify parameters prior to loading
     params.NEW_DIR_RESULTS = False
     params.output.HAS_TO_SAVE = False
     params.path_run = path_dir
+
+    if isinstance(session_id, int):
+        from snek5000.output import _make_path_session
+
+        params.output.session_id = session_id
+        params.output.path_session = _make_path_session(path_dir, session_id)
+
     sim = Simul(params)
     return sim
 

--- a/src/snek5000/output/__init__.py
+++ b/src/snek5000/output/__init__.py
@@ -22,3 +22,28 @@ def _make_path_session(path_run: str, session_id: int):
     session_id : int
     """
     return Path(path_run) / f"session_{session_id:02d}"
+
+
+def _parse_path_run_session_id(path_session):
+    """Parse `path_run` and `session_id` from path_session
+
+    Parameters
+    ----------
+    path_session : str
+
+    Returns
+    -------
+    path_dir, session_id: tuple[Path, int | None]
+        If the path is to a session_directory the `path_run` (its parent path)
+        and the `session_id` will be returned. If not the input parameter will
+        be returned as a path object unchanged, along with `None` instead
+        of `session_id`.
+
+    """
+    path_session = Path(path_session).resolve()
+
+    head, underscore, tail = path_session.name.partition("_")
+    if head == "session" and underscore == "_" and tail.isdecimal():
+        return path_session.parent, int(tail)
+    else:
+        return path_session, None

--- a/src/snek5000/output/base.py
+++ b/src/snek5000/output/base.py
@@ -14,7 +14,6 @@ from socket import gethostname
 
 from fluidsim_core.output import OutputCore
 from fluidsim_core.params import iter_complete_params
-
 from inflection import underscore
 
 from snek5000 import __version__, get_asset, logger, mpi, resources
@@ -613,6 +612,10 @@ class Output(OutputCore):
 
         index: int
             Index to match a specific field file
+
+        Returns
+        -------
+        file: Path
 
         """
         case = self.name_solver

--- a/src/snek5000/params.py
+++ b/src/snek5000/params.py
@@ -68,6 +68,11 @@ class Parameters(_Parameters):
 
     """
 
+    @classmethod
+    def _load_params_simul(cls, path=None):
+        """Alias for :func:`load_params`"""
+        return load_params(path or Path.cwd())
+
     def __init__(self, *args, **kwargs):
         comments = ("#",)
         self._set_internal_attr(

--- a/src/snek5000/solvers/__init__.py
+++ b/src/snek5000/solvers/__init__.py
@@ -95,7 +95,10 @@ def get_solver_short_name(path_dir):
         info_solver = InfoSolverNek(path_file=info_solver_xml)
         short_name = info_solver.short_name
     else:
-        logger.warning(f"The {info_solver_xml} file is missing!")
+        logger.warning(
+            f"The {info_solver_xml} file is missing! "
+            "Attempting to guess solver from the directory name."
+        )
         short_name = path_dir.absolute().name.split("_")[0]
 
     return short_name

--- a/src/snek5000/util/restart.py
+++ b/src/snek5000/util/restart.py
@@ -197,7 +197,7 @@ def load_for_restart(
     except (ValueError, OSError) as err:
         raise SnekRestartError(err) from err
 
-    status = get_status(path, params.output.session_id)
+    status = get_status(path, session_id or params.output.session_id)
 
     if verify_contents:
         if status.code >= 400:

--- a/src/snek5000/util/restart.py
+++ b/src/snek5000/util/restart.py
@@ -10,7 +10,7 @@ from warnings import warn
 from fluiddyn.io import FLUIDSIM_PATH
 
 from ..log import logger
-from ..output import _make_path_session
+from ..output import _make_path_session, _parse_path_run_session_id
 from ..params import load_params
 from ..solvers import get_solver_short_name, import_cls_simul
 from .files import next_path
@@ -191,6 +191,10 @@ def load_for_restart(
     if not path.exists():
         logger.info("Trying to open the path relative to $FLUIDSIM_PATH")
         path = Path(FLUIDSIM_PATH) / path_dir
+
+    # In case the user specifies the path to a session sub-directory
+    if session_id is None:
+        path, session_id = _parse_path_run_session_id(path)
 
     try:
         params = load_params(path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,15 +164,14 @@ rs6phill0.f00003
 
     from snek5000.output import _make_path_session
 
-    session_id = 0
-    path_session = _make_path_session(path_run, session_id)
-    path_session.mkdir()
-
     for f in files:
         (path_run / f).touch()
 
-    for f in session_files:
-        (path_session / f).touch()
+    for session_id in range(2):
+        path_session = _make_path_session(path_run, session_id)
+        path_session.mkdir()
+        for f in session_files:
+            (path_session / f).touch()
 
     from phill.solver import Simul
 

--- a/tests/test_load_simul.py
+++ b/tests/test_load_simul.py
@@ -1,0 +1,13 @@
+import pytest
+
+from snek5000 import load_simul
+
+
+def test_load_simul_error(sim_data):
+    with pytest.raises(ValueError):
+        load_simul(sim_data / "session_00")
+
+
+def test_load_simul_session(sim_data):
+    sim = load_simul(sim_data, session_id=0)
+    assert sim.params.output.session_id == 0

--- a/tests/test_load_simul.py
+++ b/tests/test_load_simul.py
@@ -3,11 +3,13 @@ import pytest
 from snek5000 import load_simul
 
 
-def test_load_simul_error(sim_data):
-    with pytest.raises(ValueError):
-        load_simul(sim_data / "session_00")
+@pytest.mark.parametrize("session_id", (0, 1))
+def test_load_simul_error(sim_data, session_id):
+    sim = load_simul(sim_data / f"session_{session_id:02d}")
+    assert sim.params.output.session_id == session_id
 
 
-def test_load_simul_session(sim_data):
-    sim = load_simul(sim_data, session_id=0)
-    assert sim.params.output.session_id == 0
+@pytest.mark.parametrize("session_id", (0, 1))
+def test_load_simul_session(sim_data, session_id):
+    sim = load_simul(sim_data, session_id=session_id)
+    assert sim.params.output.session_id == session_id

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -23,7 +23,7 @@ def test_locked(sim_data):
 
 def test_ok(sim_data):
     (sim_data / ".snakemake").mkdir()
-    session = _make_path_session(sim_data, 0)
+    session = _make_path_session(sim_data, 1)
     [file.unlink() for file in session.glob("phill*0.f?????")]
 
     assert get_status(sim_data).code == 200
@@ -44,7 +44,7 @@ def test_not_found(sim_data):
 
 def test_partial_content(sim_data):
     (sim_data / ".snakemake").mkdir()
-    session = _make_path_session(sim_data, 0)
+    session = _make_path_session(sim_data, 1)
     [restart.unlink() for restart in session.glob("rs6*")]
 
     assert get_status(sim_data).code == 206


### PR DESCRIPTION
Fixes #83

- Add session_id parameter to load_simul
- Add session_id parameter to load_for_restart
- Fail quickly if session directory is accidently provided
- Tests

Maintenance:
- Override Parameters._load_params_simul