### PR TITLE
Fix restart issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,10 @@ Security in case of vulnerabilities.
 - {mod}`snek5000.util.files`
 - {meth}`snek5000.output.base.Output.get_field_file` to locate a field file
 - Mandatory key `MPIEXEC_FLAGS` in Snakemake config
-- {class}`snek5000.output.history_points.HistoryPoints` for `Nek5000 history points
-  <https://nek5000.github.io/NekDoc/problem_setup/features.html#history-points>`__
+- {class}`snek5000.output.history_points.HistoryPoints` for {ref}`Nek5000 history points <nek:features_his>`
+- {class}`snek5000.output.phys_fields.PhysFields` now fully functional with
+  `load` and `get_var` methods provided by classes under {mod}`snek5000.output.readers`.
+- Support for number of processes detection in OAR clusters
 
 ### Changed
 
@@ -52,10 +54,15 @@ Security in case of vulnerabilities.
 - Shorter output while executing `genmap`
 - Field files will be stored in sessions enabling restart with symlinking of
   restart files and avoids clobbering existing solution files
+- Support extension `.usr.f` to facilitate syntax highlighting and which would
+  be copied as a `.usr` file upon {meth}`snek5000.output.base.Output.copy`
+- The use of `params.nek.general.user_params` are replaced by a more powerful
+  {meth}`snek5000.params.Parameters._record_nek_user_params` method. 
 
 ### Deprecated
 
 - {func}`snek5000.util.restart.prepare_for_restart`
+- Passing rules as iterables to {meth}`snek5000.make.Make.exec`. Pass positional parameters instead.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ params = Simul.create_default_params()
 
 sim = Simul(params)
 sim.make.exec()  # by default starts a run
-sim.make.exec(["mesh", "compile"])  # run rules in order
-sim.make.exec(["run"], dryrun=True)  # simulate simulation
-sim.make.exec(["run"], resources={"nproc": 2})  # actual simulation
+sim.make.exec("mesh", "compile")  # run rules in order
+sim.make.exec("run", dryrun=True)  # simulate simulation
+sim.make.exec("run", resources={"nproc": 2})  # actual simulation
 ```
 
 Check out the

--- a/docs/ipynb/executed/tuto_simul_exec.ipynb
+++ b/docs/ipynb/executed/tuto_simul_exec.ipynb
@@ -2190,7 +2190,7 @@
     }
    ],
    "source": [
-    "sim.make.exec(['run_fg'])"
+    "sim.make.exec('run_fg')"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,34 @@ write_to = "src/snek5000/_version.py"
 write_to_template = "__version__ = \"{version}\"\n"
 
 [tool.pytest.ini_options]
-addopts = "--cov=snek5000 --cov=tests --no-cov-on-fail"
+addopts = "--cov --cov-config=pyproject.toml --no-cov-on-fail"
 
 [tool.isort]
 known_first_party = ["fluiddyn", "fluidsim", "snek5000"]
 # multi_line_output = 3
 profile = "black"
 line_length = 82
+
+[tool.coverage.run]
+source = ["./src", "./tests"]
+data_file = ".coverage/coverage"
+omit = [
+    "*/try_*.py",
+    "*/_old_*.py"
+]
+
+[tool.coverage.report]
+show_missing = true
+exclude_lines = [
+    "if __name__ == .__main__.:",
+    'if "sphinx" in sys.modules:',
+    "raise ValueError",
+    "raise NotImplementedError",
+    "except KeyError:",
+    "except ImportError:",
+    "except AttributeError:",
+    "except NotImplementedError:"
+]
+
+[tool.coverage.html]
+directory = ".coverage/html"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ profile = "black"
 line_length = 82
 
 [tool.coverage.run]
-source = ["./src", "./tests"]
+source = ["snek5000", "./tests"]
 data_file = ".coverage/coverage"
 omit = [
     "*/try_*.py",

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,7 @@ docs =
 
 tests =
     pytest
+    coverage[toml]
     pytest-cov
     pytest-datadir
     ipython
@@ -92,26 +93,3 @@ max-line-length = 82
 ## Not possible because we have a git dependency in tests
 # [bdist_wheel]
 # universal = 1
-
-[coverage:run]
-source =
-  ./src
-data_file = .coverage/coverage
-omit =
-    */try_*.py
-    */_old_*.py
-
-[coverage:report]
-show_missing = True
-exclude_lines =
-    if __name__ == .__main__.:
-    if "sphinx" in sys.modules:
-    raise ValueError
-    raise NotImplementedError
-    except KeyError:
-    except ImportError:
-    except AttributeError:
-    except NotImplementedError:
-
-[coverage:html]
-directory = .coverage/html

--- a/src/snek5000/make.py
+++ b/src/snek5000/make.py
@@ -3,11 +3,10 @@
 
 """
 from typing import Iterable
+from warnings import warn
 
 from snakemake import snakemake
 from snakemake.executors import change_working_directory as change_dir
-
-from .log import logger
 
 
 def unlock(path_dir):
@@ -89,10 +88,13 @@ class Make:
 
         """
         if not isinstance(rule, str) and isinstance(rule, Iterable) and not extra_rules:
-            logger.warning(
-                f"Rules {rule} should be passed as positional arguments, i.e. a "
-                f"string or comma separated strings; and not as a {type(rule)}. "
-                "Changed in snek5000 0.8.0b0"
+            warn(
+                (
+                    f"Rules {rule} should be passed as positional arguments, "
+                    "i.e. a string or comma separated strings; and not as a "
+                    f"{type(rule)}. Changed in snek5000 0.8.0b0."
+                ),
+                DeprecationWarning,
             )
             rules = rule
         else:

--- a/src/snek5000/make.py
+++ b/src/snek5000/make.py
@@ -39,17 +39,13 @@ class Make:
         with change_dir(self.path_run):
             return snakemake(self.file, listrules=True, log_handler=self.log_handler)
 
-    def exec(
-        self, rule="run", /, *extra_rules, dryrun=False, keep_incomplete=True, **kwargs
-    ):
+    def exec(self, *rules, dryrun=False, keep_incomplete=True, **kwargs):
         """Execute snakemake rules in sequence.
 
         Parameters
-        ---------------------
-        rule: str, positional-only
-            Snakemake rules to be executed
-        *extra_rules: iterable of str, positional-only
-            Extra snakemake rules to be executed
+        ----------
+        rules: iterable of str, positional-only
+            Snakemake rules to be executed. Default rule is `"run"`
         dryrun: bool
             Dry run snakemake rules without executing
         keep_incomplete: bool
@@ -87,18 +83,26 @@ class Make:
         .. _command line arguments: https://snakemake.readthedocs.io/en/stable/executing/cli.html#useful-command-line-arguments
 
         """
-        if not isinstance(rule, str) and isinstance(rule, Iterable) and not extra_rules:
+        # Default rule
+        if not rules:
+            rules = ("run",)
+
+        # Check if rules were passed as a list / tuple (old API)
+        first_rule = rules[0]
+        if (
+            not isinstance(first_rule, str)
+            and isinstance(first_rule, Iterable)
+            and len(rules) == 1
+        ):
             warn(
                 (
-                    f"Rules {rule} should be passed as positional arguments, "
+                    f"Rules {first_rule} should be passed as positional arguments, "
                     "i.e. a string or comma separated strings; and not as a "
-                    f"{type(rule)}. Changed in snek5000 0.8.0b0."
+                    f"{type(first_rule)}. Changed in snek5000 0.8.0b0."
                 ),
                 DeprecationWarning,
             )
-            rules = rule
-        else:
-            rules = (rule, *extra_rules)
+            rules = first_rule
 
         with change_dir(self.path_run):
             return snakemake(

--- a/src/snek5000/make.py
+++ b/src/snek5000/make.py
@@ -2,8 +2,12 @@
 ======================
 
 """
+from typing import Iterable
+
 from snakemake import snakemake
 from snakemake.executors import change_working_directory as change_dir
+
+from .log import logger
 
 
 def unlock(path_dir):
@@ -36,23 +40,39 @@ class Make:
         with change_dir(self.path_run):
             return snakemake(self.file, listrules=True, log_handler=self.log_handler)
 
-    def exec(self, rules=("run",), dryrun=False, **kwargs):
+    def exec(
+        self, rule="run", /, *extra_rules, dryrun=False, keep_incomplete=True, **kwargs
+    ):
         """Execute snakemake rules in sequence.
 
-        :param iterable rules: Snakemake rules to be executed
-        :param bool dryrun: Dry run snakemake without executing
+        Parameters
+        ---------------------
+        rule: str, positional-only
+            Snakemake rules to be executed
+        *extra_rules: iterable of str, positional-only
+            Extra snakemake rules to be executed
+        dryrun: bool
+            Dry run snakemake rules without executing
+        keep_incomplete: bool
+            Keep incomplete output files of failed jobs
+
 
         For more on available keyword arguments refer to `Snakemake API documentation`_.
 
-        :returns: True if workflow execution was successful.
-
         .. _Snakemake API documentation: https://snakemake.readthedocs.io/en/stable/api_reference/snakemake.html
+
+
+        Returns
+        -------
+        bool
+            ``True`` if workflow execution was successful.
 
         Examples
         --------
 
-        >>> sim.make.exec(['compile'])
-        >>> sim.make.exec(['run'], resources={'nproc': 4})
+        >>> sim.make.exec('mesh', 'SESSION.NAME')
+        >>> sim.make.exec('compile')
+        >>> sim.make.exec('run', resources={'nproc': 4})
 
         It is also possible to do the same directly from command line
         by changing to the simulation directory and executing::
@@ -68,11 +88,22 @@ class Make:
         .. _command line arguments: https://snakemake.readthedocs.io/en/stable/executing/cli.html#useful-command-line-arguments
 
         """
+        if not isinstance(rule, str) and isinstance(rule, Iterable) and not extra_rules:
+            logger.warning(
+                f"Rules {rule} should be passed as positional arguments, i.e. a "
+                f"string or comma separated strings; and not as a {type(rule)}. "
+                "Changed in snek5000 0.8.0b0"
+            )
+            rules = rule
+        else:
+            rules = (rule, *extra_rules)
+
         with change_dir(self.path_run):
             return snakemake(
                 self.file,
                 targets=rules,
                 dryrun=dryrun,
+                keep_incomplete=keep_incomplete,
                 log_handler=self.log_handler,
                 **kwargs,
             )

--- a/src/snek5000/make.py
+++ b/src/snek5000/make.py
@@ -6,6 +6,12 @@ from snakemake import snakemake
 from snakemake.executors import change_working_directory as change_dir
 
 
+def unlock(path_dir):
+    """Unlock a directory locked using Snakemake."""
+    with change_dir(path_dir):
+        snakemake("Snakefile", unlock=True)
+
+
 class Make:
     """Snakemake interface for the solvers.
 

--- a/src/snek5000/util/restart.py
+++ b/src/snek5000/util/restart.py
@@ -108,8 +108,8 @@ def get_status(path_dir, session_id=None, verbose=False):
     if not {"SIZE", "nek5000"}.issubset(contents):
         return SimStatus.NOT_FOUND
 
-    checkpoints = set(path_session.glob("rs6*0.f?????"))
-    field_files = set(path_session.glob("*0.f?????")) - checkpoints
+    checkpoints = set(path.glob("rs6*0.f?????"))
+    field_files = set(path_session.glob("*0.f?????"))
 
     if checkpoints and field_files:
         return SimStatus.RESET_CONTENT
@@ -251,8 +251,9 @@ def load_for_restart(
             params.nek.chkpoint.chkp_fnumber = use_checkpoint
             params.nek.chkpoint.read_chkpt = True
 
-            for restart_file in old_path_session.glob(f"rs6{short_name}0.f?????"):
-                make_relative_symlink(restart_file.name)
+            # NOTE: restart files are written into in path_run and not old_path_session
+            #  for restart_file in old_path_session.glob(f"rs6{short_name}0.f?????"):
+            #      make_relative_symlink(restart_file.name)
         else:
             raise SnekRestartError(
                 f"Restart checkpoint {use_checkpoint} is invalid / does not exist"

--- a/src/snek5000/util/restart.py
+++ b/src/snek5000/util/restart.py
@@ -43,13 +43,13 @@ class SimStatus(Enum):
     )
     NOT_FOUND = (
         404,
-        "Not Found: SIZE and/or nek5000 and/or SESSION.NAME files are missing.",
+        "Not Found: SIZE and/or nek5000 is missing.",
     )
     LOCKED = (
         423,
         (
             "Locked: The path is currently locked by snakemake. "
-            "Execute `snakemake --unlock` or see prepare_for_restart function."
+            "Execute `snakemake --unlock` function snek5000.make.unlock."
         ),
     )
     TOO_EARLY = (
@@ -105,7 +105,7 @@ def get_status(path_dir, session_id=None, verbose=False):
         if locks:
             return SimStatus.LOCKED
 
-    if not {"SIZE", "SESSION.NAME", "nek5000"}.issubset(contents):
+    if not {"SIZE", "nek5000"}.issubset(contents):
         return SimStatus.NOT_FOUND
 
     checkpoints = set(path_session.glob("rs6*0.f?????"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,7 +141,7 @@ def sim_executed():
     params.nek.stat.io_step = 8
 
     sim = Simul(params)
-    assert sim.make.exec(["run_fg"]), "phill simulation failed"
+    assert sim.make.exec("run_fg"), "phill simulation failed"
     return sim
 
 
@@ -177,7 +177,7 @@ def sim_cbox_executed(monkeypatch):
     )
 
     sim = Simul(params)
-    assert sim.make.exec(["run_fg"], resources={"nproc": 2}), "cbox simulation failed"
+    assert sim.make.exec("run_fg", resources={"nproc": 2}), "cbox simulation failed"
     return sim
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,15 +195,15 @@ phill.ma2
 phill.par
 phill.re2
 phill.usr
+rs6phill0.f00001
+rs6phill0.f00002
+rs6phill0.f00003
 SESSION.NAME
 SIZE
 Snakefile""".splitlines()
 
     session_files = """
 phill0.f00001
-rs6phill0.f00001
-rs6phill0.f00002
-rs6phill0.f00003
 """.splitlines()
 
     path_run = Path(tmpdir_factory.mktemp("phill_sim_data"))

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -78,7 +78,7 @@ def test_restart(sim_executed):
     )  # In phill for some reason dt is negative
 
     sim = Simul(params)
-    sim.make.exec(["run_fg"])
+    sim.make.exec("run_fg")
 
     fld = pm.readnek(sim.output.get_field_file())
     assert fld.time == t_end

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -46,8 +46,8 @@ def test_not_found(sim_data):
 
 def test_partial_content(sim_data):
     (sim_data / ".snakemake").mkdir()
-    session = _make_path_session(sim_data, 1)
-    [restart.unlink() for restart in session.glob("rs6*")]
+    _make_path_session(sim_data, 1)
+    [restart.unlink() for restart in sim_data.glob("rs6*")]
 
     assert get_status(sim_data).code == 206
 

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1,3 +1,5 @@
+import pytest
+
 from snek5000 import load_simul
 from snek5000.solvers import available_solvers, import_cls_simul
 
@@ -43,6 +45,13 @@ def test_output(sim_data):
         sim.output.phys_fields
     except AttributeError as err:
         raise AssertionError("Cannot initialize phys_fields") from err
+
+
+def test_make_exec_deprecation(sim2d):
+    with pytest.deprecated_call():
+        sim2d.make.exec(["phill.re2", "phill.ma2"])
+
+    sim2d.make.exec("SESSION.NAME")
 
 
 def test_init_output():

--- a/tests/test_tuto_packaging.py
+++ b/tests/test_tuto_packaging.py
@@ -4,4 +4,4 @@ import pytest
 @pytest.mark.slow
 def test_package_canonical(sim_canonical):
     sim = sim_canonical
-    assert sim.make.exec(["compile"])
+    assert sim.make.exec("compile")


### PR DESCRIPTION
Fixes #90

- Do not check for SESSION.NAME with get_status, function unlock
- Look for restart checkpoints in path_run, not path_session
- Make: keep_incomplete=True, rules are positional parameters
