### PR TITLE
info_solver should be initialized in _complete_info_solver

### DIFF
--- a/docs/examples/snek5000-canonical/src/snek5000_canonical/output.py
+++ b/docs/examples/snek5000-canonical/src/snek5000_canonical/output.py
@@ -1,9 +1,18 @@
+from snek5000_canonical.templates import box, makefile_usr, size
+
 from snek5000 import mpi
 from snek5000.output.base import Output as OutputBase
-from snek5000_canonical.templates import box, size, makefile_usr
 
 
 class OutputCanonical(OutputBase):
+    @staticmethod
+    def _complete_info_solver(info_solver):
+        """Complete the ParamContainer info_solver."""
+        OutputBase._complete_info_solver(info_solver)
+
+        classes = info_solver.classes.Output.classes
+        classes.PhysFields.module_name = "snek5000_canonical.phys_fields"
+        classes.PhysFields.class_name = "PhysFieldsCanonical"
 
     @property
     def makefile_usr_sources(self):

--- a/docs/examples/snek5000-canonical/src/snek5000_canonical/output.py
+++ b/docs/examples/snek5000-canonical/src/snek5000_canonical/output.py
@@ -5,12 +5,12 @@ from snek5000.output.base import Output as OutputBase
 
 
 class OutputCanonical(OutputBase):
-    @staticmethod
-    def _complete_info_solver(info_solver):
-        """Complete the ParamContainer info_solver."""
-        OutputBase._complete_info_solver(info_solver)
+    @classmethod
+    def _set_info_solver_classes(cls, classes):
+        """Set the the classes for info_solver.classes.Output"""
+        super()._set_info_solver_classes(classes)
 
-        classes = info_solver.classes.Output.classes
+        # Replace sim.output.phys_fields with a custom classe
         classes.PhysFields.module_name = "snek5000_canonical.phys_fields"
         classes.PhysFields.class_name = "PhysFieldsCanonical"
 

--- a/docs/examples/snek5000-canonical/src/snek5000_canonical/phys_fields.py
+++ b/docs/examples/snek5000-canonical/src/snek5000_canonical/phys_fields.py
@@ -1,0 +1,35 @@
+import matplotlib.pyplot as plt
+
+from snek5000.output.phys_fields import PhysFields
+from snek5000.output.readers.pymech_ import ReaderPymech
+
+
+class ReaderPymechAvg(ReaderPymech):
+    """Horizontally and temporally averaged profiles."""
+
+    tag = "pymech_avg"
+
+    def load(self, prefix="", index="all", t_stat=None, **kwargs):
+        ds = super().load(prefix, index, **kwargs)
+
+        avg_dims = ("x", "z", "time")
+        # Use xarray's sel method to slice along time and mean method to do the
+        # averaging
+        self.data = ds.sel(time=slice(t_stat, None)).mean(avg_dims)
+        return self.data
+
+
+class PhysFieldsCanonical(PhysFields):
+    @staticmethod
+    def _complete_info_solver(info_solver, classes=None):
+        PhysFields._complete_info_solver(info_solver, classes=(ReaderPymechAvg,))
+
+    def plot_mean_vel(self, marker="x"):
+        """Plot mean velocity profiles against y-coordinate."""
+        fix, ax = plt.subplots()
+        data = self.data
+        ax.plot("ux", "y", "", marker=marker, label="$U$", data=data)
+        ax.plot("uy", "y", "", marker=marker, label="$V$", data=data)
+        ax.plot("uz", "y", "", marker=marker, label="$W$", data=data)
+        ax.set(ylabel="$y$")
+        ax.legend()

--- a/docs/packaging.rst
+++ b/docs/packaging.rst
@@ -82,6 +82,15 @@ src/snek5000_canonical/output.py
 
 .. literalinclude:: examples/snek5000-canonical/src/snek5000_canonical/output.py
 
+src/snek5000_canonical/phys_fields.py
+-------------------------------------
+
+Optionally, add classes for ``reader`` and ``phys_fields`` objects which would
+allow customized ``load``, ``get_var`` and ``plot_*`` methods suited for your
+case.
+
+.. literalinclude:: examples/snek5000-canonical/src/snek5000_canonical/output.py
+
 src/snek5000_canonical/templates/__init__.py
 --------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ profile = "black"
 line_length = 82
 
 [tool.coverage.run]
-source = ["snek5000", "./tests"]
+source = ["snek5000", "snek5000_canonical", "./tests"]
 data_file = ".coverage/coverage"
 omit = [
     "*/try_*.py",

--- a/src/snek5000/output/base.py
+++ b/src/snek5000/output/base.py
@@ -129,7 +129,7 @@ class Output(OutputCore):
         )
 
         # iteratively call _complete_info_solver of the above classes
-        # info_solver.classes.Output.complete_with_classes()
+        info_solver.classes.Output.complete_with_classes()
 
     @staticmethod
     def _complete_params_with_default(params, info_solver):
@@ -164,7 +164,6 @@ class Output(OutputCore):
         )
 
         dict_classes = info_solver.classes.Output.import_classes()
-        info_solver.classes.Output.complete_with_classes()
         iter_complete_params(params, info_solver, dict_classes.values())
 
     @classmethod

--- a/src/snek5000/output/base.py
+++ b/src/snek5000/output/base.py
@@ -16,6 +16,7 @@ from fluidsim_core.output import OutputCore
 from fluidsim_core.params import iter_complete_params
 from inflection import underscore
 
+from fluiddyn.io import stdout_redirected
 from snek5000 import __version__, get_asset, logger, mpi, resources
 from snek5000.params import _save_par_file
 from snek5000.solvers import get_solver_package, is_package
@@ -334,7 +335,11 @@ class Output(OutputCore):
             for cls_name, Class in dict_classes.items():
                 # only initialize if Class is not the Output class
                 if not isinstance(self, Class):
-                    setattr(self, underscore(cls_name), Class(self))
+                    obj_name = underscore(cls_name)
+                    setattr(self, obj_name, Class(self))
+                    self.sim._objects_to_print += "{:28s}{}\n".format(
+                        f"sim.output.{obj_name}: ", Class
+                    )
 
     def _init_path_session(self):
         """Initialize :attr:`path_session` and ``params.output.path_session``
@@ -661,14 +666,15 @@ class Output(OutputCore):
         """
 
         if mpi.rank == 0:
-            _banner_length = 42
-            logger.info("*" * _banner_length)
-            logger.info(f"solver: {self.__class__}")
             logger.info(f"path_run: {self.path_run}")
-            logger.info("*" * _banner_length)
+            logger.info(f"session_id: {self.params.session_id}")
 
         # This also calls _save_info_solver_params_xml
-        super().post_init()
+        with stdout_redirected():
+            # We gather objects to print within Snek5000
+            super().post_init()
+
+        logger.info(self.sim._objects_to_print)
 
         # Write source files to compile the simulation
         if mpi.rank == 0 and self._has_to_save and self.sim.params.NEW_DIR_RESULTS:

--- a/src/snek5000/output/base.py
+++ b/src/snek5000/output/base.py
@@ -101,13 +101,9 @@ class Output(OutputCore):
     def fortran_inc_flags(self):
         return (f"-I{inc_dir}" for inc_dir in self.makefile_usr_sources)
 
-    @staticmethod
-    def _complete_info_solver(info_solver):
-        """Complete the info_solver instance with child class details (module
-        and class names).
-
-        """
-        classes = info_solver.classes.Output._set_child("classes")
+    @classmethod
+    def _set_info_solver_classes(cls, classes):
+        """Set the the classes for info_solver.classes.Output"""
 
         classes._set_child(
             "PrintStdout",
@@ -128,6 +124,14 @@ class Output(OutputCore):
             ),
         )
 
+    @classmethod
+    def _complete_info_solver(cls, info_solver):
+        """Complete the info_solver instance with child class details (module
+        and class names).
+
+        """
+        classes = info_solver.classes.Output._set_child("classes")
+        cls._set_info_solver_classes(classes)
         # iteratively call _complete_info_solver of the above classes
         info_solver.classes.Output.complete_with_classes()
 

--- a/src/snek5000/output/phys_fields.py
+++ b/src/snek5000/output/phys_fields.py
@@ -61,7 +61,12 @@ class PhysFields:
 
     @property
     def data(self):
-        return self._reader.data
+        data = self._reader.data
+        if not data:
+            raise IOError(
+                "No data has been loaded yet. Try calling sim.output.phys_fields.load() first."
+            )
+        return data
 
     def __init__(self, output=None):
         self.output = output

--- a/src/snek5000/solvers/base.py
+++ b/src/snek5000/solvers/base.py
@@ -252,13 +252,18 @@ class SimulNek(SimulCore):
     def __init__(self, params):
         super().__init__(params)
 
+        self._objects_to_print = "{:28s}{}\n".format("sim: ", type(self))
         dict_classes = self.info_solver.import_classes()
 
         # initialize objects
         for cls_name, Class in dict_classes.items():
             # only initialize if Class is not the Simul class
             if not isinstance(self, Class):
-                setattr(self, underscore(cls_name), Class(self))
+                obj_name = underscore(cls_name)
+                setattr(self, obj_name, Class(self))
+                self._objects_to_print += "{:28s}{}\n".format(
+                    f"sim.{obj_name}: ", Class
+                )
 
         if "Output" in dict_classes:
             if not params.NEW_DIR_RESULTS:

--- a/tests/test_tuto_packaging.py
+++ b/tests/test_tuto_packaging.py
@@ -1,4 +1,20 @@
+import sys
+
 import pytest
+
+from snek5000 import load
+
+
+def test_load(sim_canonical):
+    # Reload snek5000_canonical so that the load method would freshly import snek5000_canonical
+    # https://stackoverflow.com/a/57851153
+    for module in tuple(sys.modules):
+        if module.startswith("snek5000_canonical"):
+            del sys.modules[module]
+
+    sim2 = load(sim_canonical.path_run, reader="pymech_avg")
+    with pytest.raises(FileNotFoundError):
+        sim2.output.phys_fields.plot_mean_vel()
 
 
 @pytest.mark.slow

--- a/tests/test_tuto_packaging.py
+++ b/tests/test_tuto_packaging.py
@@ -13,7 +13,7 @@ def test_load(sim_canonical):
             del sys.modules[module]
 
     sim2 = load(sim_canonical.path_run, reader="pymech_avg")
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(IOError, match="No data has been loaded yet."):
         sim2.output.phys_fields.plot_mean_vel()
 
 


### PR DESCRIPTION
Fixes #106  

Without this, I get 

```
pierre@gre ~/Sim_data/cbox/2D/NL_sim/asp_1.00/msh_72_72/Ra_1.000e+08/cbox_run_8x8x8_V1.x1.x1._2021-11-15_12-08-19 $ ipython --matplotlib -i -c "from snek5000 import load; sim = load()"               
Python 3.9.6 (default, Jul 19 2021, 11:14:16) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.25.0 -- An enhanced Interactive Python. Type '?' for help.
Using matplotlib backend: Qt5Agg
sim:                <class 'snek5000_cbox.solver.SimulCbox'>
sim.output:         <class 'snek5000_cbox.output.OutputCbox'>
[11/15/21 16:03:16] INFO     ******************************************                                                                                                                     base.py:662
                    INFO     solver: <class 'snek5000_cbox.output.OutputCbox'>                                                                                                              base.py:663
                    INFO     path_run: /home/pierre/Sim_data/cbox/2D/NL_sim/asp_1.00/msh_72_72/Ra_1.000e+08/cbox_run_8x8x8_V1.x1.x1._2021-11-15_12-08-19                                    base.py:664
                    INFO     ******************************************                                                                                                                     base.py:665
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-1-9bf224db26da> in <module>
----> 1 from snek5000 import load; sim = load()

~/Dev/snek5000/src/snek5000/__init__.py in load_simul(path_dir, session_id, reader)
    154     if reader:
    155         if reader is True:
--> 156             sim.output.phys_fields.init_reader()
    157         elif isinstance(reader, str):
    158             sim.output.phys_fields.change_reader(reader)

~/Dev/snek5000/src/snek5000/output/phys_fields.py in init_reader(self)
    108 
    109         reader_key = self.params.phys_fields.reader
--> 110         self.change_reader(reader_key)
    111 
    112     def change_reader(self, reader_key):

~/Dev/snek5000/src/snek5000/output/phys_fields.py in change_reader(self, reader_key)
    123 
    124         dict_classes = (
--> 125             sim.info.solver.classes.Output.classes.PhysFields.import_classes()
    126         )
    127         try:

~/.pyenv/versions/3.9.6/lib/python3.9/site-packages/fluidsim_core/info.py in import_classes(self)
    108 
    109         dict_classes = {}
--> 110         tags = self.classes._tag_children
    111         if len(tags) == 0:
    112             self._set_internal_attr("_cached_imported_classes", dict_classes)

~/.pyenv/versions/3.9.6/lib/python3.9/site-packages/fluiddyn/util/paramcontainer.py in __getattr__(self, attr)
    240 
    241         else:
--> 242             raise AttributeError(
    243                 attr
    244                 + " is not an attribute of "

AttributeError: classes is not an attribute of PhysFields.
The attributes are: ['module_name', 'class_name']
The children are: []
```