### PR TITLE
Standalone Nek5000Make class

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,8 @@ jobs:
       run: |
         source activate.sh
         export SNEK_DEBUG=1
+        pytest -v tests/test_make.py &
+        pytest -v tests/test_make.py
         pytest -v --runslow --cov-report=xml --cov-report=term-missing
 
     - name: Upload coverage to codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,9 +59,7 @@ jobs:
       run: |
         source activate.sh
         export SNEK_DEBUG=1
-        pytest -v --cov-report=xml tests/test_make.py &
-        pytest -v --no-cov tests/test_make.py
-        pytest -v --runslow --cov-report=xml --cov-append --cov-report=term-missing
+        pytest -v --runslow --cov-report=xml --cov-report=term-missing
 
     - name: Upload coverage to codecov
       if: ${{ success() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,6 +112,7 @@ jobs:
 
     - name: Build docs
       run: |
+        source activate.sh
         SPHINXOPTS="-W" make -C docs html
 
   deploy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,6 +78,11 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Install apt packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install gfortran libopenmpi-dev
+
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: recursive
-        fetch-depth: 0
 
     - name: Install apt packages
       run: |
@@ -112,7 +111,6 @@ jobs:
 
     - name: Build docs
       run: |
-        source activate.sh
         SPHINXOPTS="-W" make -C docs html
 
   deploy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,9 +59,9 @@ jobs:
       run: |
         source activate.sh
         export SNEK_DEBUG=1
-        pytest -v tests/test_make.py &
-        pytest -v tests/test_make.py
-        pytest -v --runslow --cov-report=xml --cov-report=term-missing
+        pytest -v --cov-report=xml tests/test_make.py &
+        pytest -v --no-cov tests/test_make.py
+        pytest -v --runslow --cov-report=xml --cov-append --cov-report=term-missing
 
     - name: Upload coverage to codecov
       if: ${{ success() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,6 +77,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: recursive
+        fetch-depth: 0
 
     - name: Install apt packages
       run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "lib/Nek5000"]
 	path = lib/Nek5000
-	url = https://github.com/Nek5000/Nek5000.git
+	url = https://github.com/exabl/Nek5000.git
 	ignore = dirty

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,12 @@ sys.path.insert(0, root(breathe))
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, root(snek5000))
+os.environ["NEK_SOURCE_ROOT"] = os.fspath(
+    (Path(__file__).parent.parent / "lib" / "Nek5000").resolve()
+)
 
+
+print("NEK_SOURCE_ROOT = ", snek5000.get_nek_source_root())
 print("sys.path =\n   ", "\n    ".join(sys.path))
 
 # -- Project information -----------------------------------------------------

--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -73,3 +73,22 @@ the following function call.
    Output.update_snakemake_config(config, CASE, env_sensitive=True)
 
 See :meth:`snek5000.output.base.Output.update_snakemake_config` and :ref:`user_snakefile` for more details
+
+
+On compiling and running simultaneous simulations
+-------------------------------------------------
+
+Snek5000 supports compiling multiple simulation runs from different terminals
+or cluster jobs in realtime. It will also take care of rebuilding the Nek5000
+libraries if the compiler configuration changes. We use the ``filelock``
+library to avoid multiple rebuilds. See :ref:`nek5000make` for more
+information.
+
+.. warning::
+
+    There is a small caveat with this solution. If a series of jobs are
+    launched which uses various compiler configurations, then it would
+    rebuild Nek5000 tools and libraries again and again during
+    ``sim.output.post_init`` - and suddenly some library would be missing
+    during the ``sim.make.exec`` call. As long as all subsequent jobs use
+    the same compiler configuration, it should work.

--- a/docs/dev/output.rst
+++ b/docs/dev/output.rst
@@ -12,3 +12,12 @@ Internal API of Output
 .. automethod:: snek5000.output.base.Output._get_resources
 .. automethod:: snek5000.output.base.Output._get_subpackages
 .. automethod:: snek5000.output.base.Output._save_info_solver_params_xml
+
+
+Class _Nek5000Make
+------------------
+
+:meth:`snek5000.output.base.Output.build_nek5000` relies on:
+
+.. autoclass:: snek5000.make._Nek5000Make
+

--- a/docs/dev/output.rst
+++ b/docs/dev/output.rst
@@ -14,6 +14,8 @@ Internal API of Output
 .. automethod:: snek5000.output.base.Output._save_info_solver_params_xml
 
 
+.. _nek5000make:
+
 Class _Nek5000Make
 ------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     inflection
     importlib_resources; python_version < "3.7"
     pyyaml
+    filelock
 
 [options.entry_points]
 snek5000.solvers =

--- a/src/snek5000/assets/compiler.smk
+++ b/src/snek5000/assets/compiler.smk
@@ -14,23 +14,6 @@ rule show_config:
         pprint(config)
 
 
-# gslib, lapack ...
-rule build_third_party:
-    input:
-        # ".state",
-        config["file"],
-        nekconfig=NEK_SOURCE_ROOT + "/bin/nekconfig",
-    output:
-        NEK_SOURCE_ROOT + "/3rd_party/gslib/lib/libgs.a",
-        NEK_SOURCE_ROOT + "/3rd_party/blasLapack/libblasLapack.a",
-    shell:
-        """
-        export CC="{config[MPICC]}" FC="{config[MPIFC]}" \
-            CFLAGS="{config[CFLAGS]}" FFLAGS="{config[FFLAGS]}"
-        {input.nekconfig} -build-dep
-        """
-
-
 # compile
 rule compile:
     input:

--- a/src/snek5000/assets/internal.smk
+++ b/src/snek5000/assets/internal.smk
@@ -5,20 +5,11 @@ from snek5000.util.files import create_session
 NEK_SOURCE_ROOT = snek5000.get_nek_source_root()
 
 
-subworkflow Nek5000:
-    workdir:
-        NEK_SOURCE_ROOT
-    snakefile:
-        snek5000.get_asset("nek5000.smk")
-    configfile:
-        config["file"]
-
-
 # generate a box mesh
 rule generate_box:
     input:
         box=f"{config['CASE']}.box",
-        genbox=Nek5000("bin/genbox"),
+        genbox=NEK_SOURCE_ROOT + "/bin/genbox",
     output:
         "box.re2",
     shell:
@@ -39,7 +30,7 @@ rule move_box:
 rule generate_map:
     input:
         f"{config['CASE']}.re2",
-        genmap=Nek5000("bin/genmap"),
+        genmap=NEK_SOURCE_ROOT + "/bin/genmap",
     output:
         f"{config['CASE']}.ma2",
     resources:

--- a/src/snek5000/assets/nek5000.smk
+++ b/src/snek5000/assets/nek5000.smk
@@ -36,12 +36,15 @@ rule tools_clean:
 
 # NOTE: May not compile as needed unless proper flags are supplied. The command
 # makenek takes care of gslib building using the bash function make_3rd_party
-rule gslib:
+rule build_third_party:
+    input:
+        nekconfig="bin/nekconfig",
     output:
         "3rd_party/gslib/lib/libgs.a",
-    params:
-        flags=MAKETOOLS.replace("./maketools", ""),
+        "3rd_party/blasLapack/libblasLapack.a",
     shell:
         """
-        {params.flags} ./bin/nekconfig -build-dep
+        export CC="{config[MPICC]}" FC="{config[MPIFC]}" \
+            CFLAGS="{config[CFLAGS]}" FFLAGS="{config[FFLAGS]}"
+        {input.nekconfig} -build-dep
         """

--- a/src/snek5000/assets/nek5000.smk
+++ b/src/snek5000/assets/nek5000.smk
@@ -14,6 +14,7 @@ rule tools:
 rule _tool:
     input:
         "tools/{tool}",
+        "nek5000_make_config.yml",
     output:
         "bin/{tool}",
     params:
@@ -38,6 +39,7 @@ rule tools_clean:
 # makenek takes care of gslib building using the bash function make_3rd_party
 rule build_third_party:
     input:
+        "nek5000_make_config.yml",
         nekconfig="bin/nekconfig",
     output:
         "3rd_party/gslib/lib/libgs.a",

--- a/src/snek5000/assets/nek5000.smk
+++ b/src/snek5000/assets/nek5000.smk
@@ -39,9 +39,9 @@ rule tools_clean:
 rule gslib:
     output:
         "3rd_party/gslib/lib/libgs.a",
+    params:
+        flags=MAKETOOLS.replace("./maketools", ""),
     shell:
         """
-        source core/makenek.inc
-        pushd 3rd_party/gslib
-        CC={config[CC]} CFLAGS={config[CFLAGS]} ./install
+        {params.flags} ./bin/nekconfig -build-dep
         """

--- a/src/snek5000/make.py
+++ b/src/snek5000/make.py
@@ -143,7 +143,12 @@ class _Nek5000Make(Make):
         self.file = snek5000.get_asset("nek5000.smk")
         self.lock = FileLock(self.path_run / "nek5000_make.lock")
         self.config_cache = self.path_run / "nek5000_make_config.yml"
-        self.targets = ["bin/genbox", "bin/genmap", "3rd_party/gslib/lib/libgs.a"]
+        self.targets = [
+            "bin/genbox",
+            "bin/genmap",
+            "3rd_party/gslib/lib/libgs.a",
+            "3rd_party/blasLapack/libblasLapack.a",
+        ]
 
         # TODO: replace with Snek5000 log handler?
         self.log_handler = []

--- a/src/snek5000/make.py
+++ b/src/snek5000/make.py
@@ -140,15 +140,6 @@ class _Nek5000Make(Make):
     This class would prevent unnecessary rebuild of Nek5000 if there is no
     change in the compiler configuration.
 
-    .. note::
-
-        There is a small caveat with this solution. If a series of jobs are
-        launched which uses various compiler configurations, then it would
-        rebuild Nek5000 tools and libraries again and again during
-        ``sim.output.post_init`` - and suddenly some library would be missing
-        during the ``sim.make.exec`` call. As long as all subsequent jobs use
-        the same compiler configuration, it should work.
-
     """
 
     def __init__(self):

--- a/src/snek5000/make.py
+++ b/src/snek5000/make.py
@@ -141,7 +141,7 @@ class _Nek5000Make(Make):
     def __init__(self):
         self.path_run = Path(snek5000.get_nek_source_root())
         self.file = snek5000.get_asset("nek5000.smk")
-        self.lock = FileLock(self.path_run / "nek5000_make.lock")
+        self.lock = FileLock(self.path_run / "nek5000_make_config.yml.lock")
         self.config_cache = self.path_run / "nek5000_make_config.yml"
         self.targets = [
             "bin/genbox",

--- a/src/snek5000/make.py
+++ b/src/snek5000/make.py
@@ -2,11 +2,16 @@
 ======================
 
 """
+from pathlib import Path
 from typing import Iterable
 from warnings import warn
 
+import yaml
+from filelock import FileLock
 from snakemake import snakemake
 from snakemake.executors import change_working_directory as change_dir
+
+import snek5000
 
 
 def unlock(path_dir):
@@ -128,3 +133,71 @@ class Make:
                 log_handler=self.log_handler,
                 **kwargs,
             )
+
+
+class _Nek5000Make(Make):
+    """Snakemake interface to build Nek5000 tools and other dependencies."""
+
+    def __init__(self):
+        self.path_run = Path(snek5000.get_nek_source_root())
+        self.file = snek5000.get_asset("nek5000.smk")
+        self.lock = FileLock(self.path_run / "nek5000_make.lock")
+        self.config_cache = self.path_run / "nek5000_make_config.yml"
+        self.targets = ["bin/genbox", "bin/genmap", "3rd_party/gslib/lib/libgs.a"]
+
+        # TODO: replace with Snek5000 log handler?
+        self.log_handler = []
+
+    def has_to_build(self, compiler_config):
+        compiler_config_str = yaml.safe_dump(compiler_config)
+        compiler_config_cache = (
+            self.config_cache.read_text() if self.config_cache.exists() else ""
+        )
+
+        if (
+            # One or more of the targets do not exist
+            any(not (self.path_run / target).exists() for target in self.targets)
+            or compiler_config_str != compiler_config_cache
+            # New compiler configuration
+        ):
+            # Save new configuration first
+            self.config_cache.write_text(compiler_config_str)
+
+            return True
+        else:
+            return False
+
+    def build(self, config):
+        """Build Nek5000 tools and third party libraries essential for a
+        simulation.
+
+        Parameters
+        ----------
+        config: dict
+            Snakemake configuration
+
+        Returns
+        -------
+        bool
+            ``True`` if workflow execution was successful.
+
+        """
+
+        compiler_config = {
+            key: config[key]
+            for key in (
+                "CC",
+                "FC",
+                "MPICC",
+                "MPIFC",
+                "CFLAGS",
+                "FFLAGS",
+            )
+        }
+
+        with self.lock:
+            # Only one process can inspect at a time. No timeout
+            if self.has_to_build(compiler_config):
+                return self.exec(*self.targets, config=config)
+            else:
+                return True

--- a/src/snek5000/output/base.py
+++ b/src/snek5000/output/base.py
@@ -643,6 +643,26 @@ class Output(OutputCore):
         return config
 
     @staticmethod
+    def build_nek5000(config):
+        """Build Nek5000, if needed. This method is automatically invoked
+        during :meth:`post_init`.
+
+        Examples
+        --------
+        If compiler configuration is changed via a script after Simulation
+        initialization, a rebuild can be manually triggered as follows:
+
+        >>> config = sim.output.write_snakemake_config(
+        ...     custom_env_vars={"CFLAGS": "-O0 -g", FFLAGS": "-O0 -g"}
+        ... )
+        >>> sim.output.build_nek5000(config)
+
+        """
+        nek5000 = _Nek5000Make()
+        if not nek5000.build(config):
+            raise RuntimeError("Nek5000 build failed.")
+
+    @staticmethod
     def write_compile_sh(template, config, fp=None, path=None):
         """Write a standalone ``compile.sh`` shell script to compile the user
         code.
@@ -749,11 +769,7 @@ class Output(OutputCore):
         if mpi.rank == 0 and self._has_to_save and self.sim.params.NEW_DIR_RESULTS:
             self.copy(self.path_run)
             config = self.write_snakemake_config()
-
-            # Build Nek5000 if needed
-            nek5000 = _Nek5000Make()
-            if not nek5000.build(config):
-                raise RuntimeError("Nek5000 build failed.")
+            self.build_nek5000(config)
 
     def _save_info_solver_params_xml(self, replace=False):
         """Saves the par file, along with ``params_simul.xml`` and

--- a/src/snek5000/output/base.py
+++ b/src/snek5000/output/base.py
@@ -19,6 +19,7 @@ from inflection import underscore
 
 from fluiddyn.io import stdout_redirected
 from snek5000 import __version__, get_asset, logger, mpi, resources
+from snek5000.make import _Nek5000Make
 from snek5000.params import _save_par_file
 from snek5000.solvers import get_solver_package, is_package
 from snek5000.util import docstring_params
@@ -640,6 +641,11 @@ class Output(OutputCore):
         config.update(custom_env_vars)
         with open(path_configfile_simul, "w") as file:
             yaml.dump(config, file)
+
+        # Build Nek5000 if needed
+        nek5000 = _Nek5000Make()
+        if not nek5000.build(config):
+            raise RuntimeError("Nek5000 build failed.")
 
     @staticmethod
     def write_compile_sh(template, config, fp=None, path=None):

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -1,9 +1,27 @@
-def test_nek5000_make():
+from concurrent.futures import ProcessPoolExecutor as Pool
+from pathlib import Path
+
+
+def nek5000_build(config):
+    from snek5000.make import _Nek5000Make
+
+    nm = _Nek5000Make()
+    return nm.build(config)
+
+
+def test_nek5000_make(pytestconfig):
     import yaml
 
-    from snek5000.make import _Nek5000Make
+    import snek5000
     from snek5000.output.base import Output
 
-    config = yaml.safe_load(Output.find_configfile().read_text())
-    nm = _Nek5000Make()
-    assert nm.build(config)
+    if pytestconfig.getoption("--runslow"):
+        # To force rebuild of Nek5000
+        (Path(snek5000.get_nek_source_root()) / "bin" / "genbox").unlink()
+
+    snek5000_config = yaml.safe_load(Output.find_configfile().read_text())
+
+    with Pool(max_workers=4) as pool:
+        # Launch simultaneous builds
+        for future in (pool.submit(nek5000_build, snek5000_config) for _ in range(4)):
+            assert future.result()

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -1,0 +1,9 @@
+def test_nek5000_make():
+    import yaml
+
+    from snek5000.make import _Nek5000Make
+    from snek5000.output.base import Output
+
+    config = yaml.safe_load(Output.find_configfile().read_text())
+    nm = _Nek5000Make()
+    assert nm.build(config)


### PR DESCRIPTION
Fixes #53, #116

- Simpler gslib rule, _Nek5000Make class
- Remove Snakemake rules with output to Nek5000 source root
- Invoke _Nek5000Make.build during simulation init
